### PR TITLE
refactor(Modal): Refactor Modal Logical Connectives

### DIFF
--- a/Logic/Modal/LogicSymbol.lean
+++ b/Logic/Modal/LogicSymbol.lean
@@ -15,19 +15,21 @@ namespace UnaryModalOperator
 variable [UnaryModalOperator ι F]
 variable {i : ι} {p q : F}
 
-@[simp] lemma mop_injective' : ((mop i) p) = ((mop i) q) ↔ p = q := by constructor; intro h; exact mop_injective h; simp_all;
+@[simp]
+lemma mop_injective' : ((mop i) p) = ((mop i) q) ↔ p = q := by
+  constructor;
+  . intro h; exact mop_injective h;
+  . simp_all;
 
-@[simp] lemma multimop_zero : (mop i)^[0] p = p := rfl
-
-lemma multimop_succ : (mop i)^[(n + 1)] p = (mop i)^[n] ((mop i) p) := by apply iterate_succ_apply
-
-@[simp] lemma multimop_succ' : (mop i)^[(n + 1)] p = (mop i) ((mop i)^[n] p) := by apply iterate_succ_apply'
-
-lemma multimop_prepost : ((mop i) ((mop i)^[n] p)) = ((mop i)^[n] ((mop i) p)) := by induction n <;> simp_all
-
-@[simp] lemma multimop_injective' : ((mop i)^[n] p = (mop i)^[n] q) ↔ (p = q) := by induction n <;> simp [*]
+@[simp] lemma multimop_succ : (mop i)^[(n + 1)] p = (mop i) ((mop i)^[n] p) := by apply iterate_succ_apply'
 
 @[simp] lemma multimop_injective : Function.Injective (((mop i)^[n]) : F → F) := by apply Function.Injective.iterate (by simp);
+
+@[simp]
+lemma multimop_injective' : ((mop i)^[n] p = (mop i)^[n] q) ↔ (p = q) := by
+  constructor;
+  . intro h; exact multimop_injective h;
+  . simp_all;
 
 end UnaryModalOperator
 
@@ -39,104 +41,79 @@ section
 open LO UnaryModalOperator
 
 variable [UnaryModalOperator ι F] [DecidableEq F]
-variable {i : ι} {n : ℕ} {a : F}
+variable {i : ι} {n : ℕ} {p q : F}
 
 namespace Set
 
-variable {s t : Set F}
 
 protected abbrev mop (i : ι) : Set F → Set F := image (mop i)
 
 protected abbrev multimop (i : ι) (n : ℕ) : Set F → Set F := image (mop i)^[n]
 
-@[simp] lemma mop_iff_multimop_one : (Set.mop i s) = (Set.multimop i 1 s) := by rfl
+protected abbrev premop (i : ι) : Set F → Set F := preimage (mop i)
+
+protected abbrev premultimop (i : ι) (n : ℕ) : Set F → Set F := preimage (mop i)^[n]
+
+variable {s t : Set F}
+
+@[simp] lemma mop_iff_multimop_one : s.mop i = s.multimop i 1 := by rfl
+
+@[simp] lemma premop_iff_premultimop_one : s.premop i = s.premultimop i 1 := by rfl
 
 
-protected abbrev premultimop (i : ι) (n : ℕ) : Set F → Set F := Set.preimage ((mop i)^[n])
+lemma multimop_subset (h : s ⊆ t) : s.multimop i n ⊆ t.multimop i n := by simp_all [Set.subset_def];
 
-protected abbrev premop (i : ι) : Set F → Set F := Set.premultimop i 1
+lemma premultimop_subset (h : s ⊆ t) : s.premultimop i n ⊆ t.premultimop i n := by simp_all [Set.subset_def];
 
-@[simp] lemma premop_iff_premultimop_one : (Set.premop i s) = (Set.premultimop i 1 s) := by rfl
-
-
-@[simp] lemma multimop_subset (h : s ⊆ t) : (Set.multimop i n s) ⊆ (Set.multimop i n t) := by simp_all [Set.subset_def];
-
-lemma multimop_mem_iff : a ∈ (Set.multimop i n s) ↔ (∃ b ∈ s, (mop i)^[n] b = a) := by simp_all [Set.mem_image, Set.multimop];
-
-lemma forall_multimop_of_subset_multimop (h : s ⊆ Set.multimop i n t) : ∀ p ∈ s, ∃ q ∈ t, p = (mop i)^[n] q := by
-  intro p hp;
-  obtain ⟨q, hq₁, hq₂⟩ := h hp;
-  use q;
-  simp_all;
-
-protected lemma mop_injective : Function.Injective (λ {s : Set F} => Set.mop i s) := Function.Injective.image_injective mop_injective
-
-lemma forall_mop_of_subset_mop (h : s ⊆ (Set.mop i t)) : ∀ p ∈ s, ∃ q ∈ t, p = mop i q := forall_multimop_of_subset_multimop (by simpa using h)
-
-
-
-lemma multimop_premultimop_eq : (Set.premultimop i n) (Set.multimop i n s) = s := by
-  apply Set.preimage_image_eq;
-  exact multimop_injective;
-
-lemma premultimop_multimop_eq_of_subset_premultimop (hs : s ⊆ Set.multimop i n t) : Set.multimop i n ((Set.premultimop i n) s) = s := by
-  apply Set.eq_of_subset_of_subset;
-  . intro p hp;
-    obtain ⟨q, hq₁, hq₂⟩ := hp;
-    simp_all [Set.premultimop];
-  . intro p hp;
-    obtain ⟨q, _, hq₂⟩ := forall_multimop_of_subset_multimop hs p hp;
-    simp_all [Set.premultimop];
-
-
-
-lemma premultimop_subset (h : s ⊆ t) : ((Set.premultimop i n) s) ⊆ ((Set.premultimop i n) t) := by simp_all [Set.subset_def];
-
-lemma subset_premulitimop_iff_multimop_subset (h : s ⊆ (Set.premultimop i n) t) : Set.multimop i n s ⊆ t := by
+lemma subset_premulitimop_iff_multimop_subset (h : s ⊆ t.premultimop i n) : s.multimop i n ⊆ t := by
   intro p hp;
   obtain ⟨_, h₁, h₂⟩ := multimop_subset h hp;
   subst h₂;
   assumption;
 
-lemma subset_multimop_iff_premulitimop_subset (h : s ⊆ (Set.multimop i n t)) : ((Set.premultimop i n) s) ⊆ t := by
+lemma subset_multimop_iff_premulitimop_subset (h : s ⊆ t.multimop i n) : s.premultimop i n ⊆ t := by
   intro p hp;
   obtain ⟨_, h₁, h₂⟩ := premultimop_subset h hp;
   simp_all;
 
-@[simp] lemma mop_premop_eq : (Set.premop i $ Set.mop i s) = s := by apply multimop_premultimop_eq;
+lemma forall_multimop_of_subset_multimop (h : s ⊆ t.multimop i n) : ∀ p ∈ s, ∃ q ∈ t, p = (mop i)^[n] q := by
+  intro p hp;
+  obtain ⟨q, hq₁, hq₂⟩ := h hp;
+  use q;
+  simp_all;
 
-lemma premop_mop_eq_of_subset_mop (hs : s ⊆ (Set.mop i t)) : (Set.mop i $ Set.premop i s) = s := premultimop_multimop_eq_of_subset_premultimop hs
-
-lemma premop_subset (h : s ⊆ t) : (Set.premop i s) ⊆ (Set.premop i t) := premultimop_subset h
-
-lemma subset_premop_iff_mop_subset (h : s ⊆ Set.premop i t) : (Set.mop i s) ⊆ t := subset_premulitimop_iff_multimop_subset h
-
-lemma subset_mop_iff_premop_subset (h : s ⊆ Set.mop i t) : (Set.premop i s) ⊆ t := subset_multimop_iff_premulitimop_subset h
+lemma premultimop_multimop_eq_of_subset_premultimop (h : s ⊆ t.multimop i n) : (s.premultimop i n |>.multimop i n) = s := by
+  apply Set.eq_of_subset_of_subset;
+  . intro p hp;
+    obtain ⟨q, hq₁, hq₂⟩ := hp;
+    simp_all [Set.premultimop];
+  . intro p hp;
+    obtain ⟨q, _, hq₂⟩ := forall_multimop_of_subset_multimop h p hp;
+    simp_all [Set.premultimop];
 
 end Set
 
 
 namespace List
 
-open LO
-open UnaryModalOperator
-
-variable {l : List F}
-
 protected abbrev mop (i : ι) : List F → List F := List.map (mop i)
 
 protected abbrev multimop (i : ι) (n : ℕ) : List F → List F := List.map ((mop i)^[n])
 
-protected abbrev premultimop (i : ι) (n : ℕ) := List.filter (λ (p : F) => (mop i)^[n] p ∈ l)
+protected abbrev premultimop (i : ι) (n : ℕ) (l : List F) := l.filter (λ (p : F) => (mop i)^[n] p ∈ l)
 
 protected abbrev premop (i : ι) (l : List F) := l.filter (λ (p : F) => (mop i) p ∈ l)
+
+variable {l : List F}
+
+@[simp] lemma mop_iff_multimop_one : l.mop i = l.multimop i 1 := by rfl
+
+@[simp] lemma iff_premop_premultimop_one : l.premop i = l.premultimop i 1 := by rfl
 
 end List
 
 
 namespace Finset
-
-variable {s t : Finset F}
 
 protected noncomputable abbrev multimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := (s.toList).multimop i n |>.toFinset
 
@@ -146,21 +123,20 @@ protected noncomputable abbrev premultimop (i : ι) (n : ℕ) (s : Finset F) : F
 
 protected noncomputable abbrev premop (i : ι) (s : Finset F) : Finset F := s.premultimop i 1
 
-lemma multimop_coe : ↑(Finset.multimop i n s : Finset F) = Set.multimop i n (↑s : Set F) := by simp_all [Set.multimop, List.multimop]; rfl;
+variable {s t : Finset F}
 
-@[simp]
-lemma multimop_union : (Finset.multimop i n (s ∪ t) : Finset F) = (Finset.multimop i n s ∪ Finset.multimop i n t) := by
-  simp [List.toFinset_map];
-  aesop;
+@[simp] lemma iff_mop_multimop_one : s.mop i = s.multimop i 1 := by rfl;
 
-lemma multimop_mem_coe {s : Finset F} : a ∈ Finset.multimop i n s ↔ a ∈ Set.multimop i n (↑s : Set F) := by
-  constructor <;> simp_all [Set.multimop];
+@[simp] lemma iff_premop_premultimop_one : s.premop i = s.premultimop i 1 := by rfl;
+
+
+lemma multimop_coe : ↑(s.multimop i n) = (↑s : Set F).multimop i n := by simp_all; rfl;
+
+lemma multimop_mem_coe : p ∈ s.multimop i n ↔ p ∈ (↑s : Set F).multimop i n := by constructor <;> simp_all
 
 lemma premultimop_coe : ↑(s.premultimop i n) = (↑s : Set F).premultimop i n := by apply Finset.coe_preimage;
 
-lemma premop_coe : ↑(s.premop i) = (↑s : Set F).premop i := by apply premultimop_coe;
-
-lemma premultimop_multimop_eq_of_subset_multimop {s : Finset F} {t : Set F} (hs : ↑s ⊆ Set.multimop i n t) : (s.premultimop i n).multimop i n = s := by
+lemma premultimop_multimop_eq_of_subset_multimop {s : Finset F} {t : Set F} (hs : ↑s ⊆ t.multimop i n) : (s.premultimop i n).multimop i n = s := by
   have := Set.premultimop_multimop_eq_of_subset_premultimop hs;
   rw [←premultimop_coe, ←multimop_coe] at this;
   exact Finset.coe_inj.mp this;
@@ -175,30 +151,28 @@ namespace LO
 open UnaryModalOperator
 
 /--
-  Standard modal logic, which has 2 modal unary operators `□`, `◇`, and `◇` is defined as dual of `□`
+  Symbols for standard modal logic, which has 2 modal unary operators `□`, `◇`, and `◇` is defined as dual of `□`
 -/
 class StandardModalLogicalConnective (F : Sort _) extends LogicalConnective F, UnaryModalOperator Bool F where
   duality {p : F} : (mop false) p = ~((mop true) (~p))
 
 namespace StandardModalLogicalConnective
 
-variable [StandardModalLogicalConnective F] [DecidableEq F]
+variable [StandardModalLogicalConnective F]
 
-@[match_pattern]
 abbrev box : F → F := mop true
-prefix:74 "□" => StandardModalLogicalConnective.box
+prefix:74 "□" => box
 
-@[match_pattern]
 abbrev dia : F → F := mop false
-prefix:74 "◇" => StandardModalLogicalConnective.dia
+prefix:74 "◇" => dia
 
-lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply StandardModalLogicalConnective.duality
+lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply duality
 
 abbrev multibox (n : ℕ) : F → F := (mop true)^[n]
-notation:74 "□[" n:90 "]" p:80 => StandardModalLogicalConnective.multibox n p
+notation:74 "□[" n:90 "]" p:80 => multibox n p
 
 abbrev multidia (n : ℕ) : F → F := (mop false)^[n]
-notation:74 "◇[" n:90 "]" p:80 => StandardModalLogicalConnective.multidia n p
+notation:74 "◇[" n:90 "]" p:80 => multidia n p
 
 end LO.StandardModalLogicalConnective
 

--- a/Logic/Modal/LogicSymbol.lean
+++ b/Logic/Modal/LogicSymbol.lean
@@ -169,10 +169,10 @@ prefix:74 "◇" => dia
 lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply duality
 
 abbrev multibox (n : ℕ) : F → F := (mop true)^[n]
-notation:74 "□[" n:90 "]" p:80 => multibox n p
+notation:74 "□^[" n:90 "]" p:80 => multibox n p
 
 abbrev multidia (n : ℕ) : F → F := (mop false)^[n]
-notation:74 "◇[" n:90 "]" p:80 => multidia n p
+notation:74 "◇^[" n:90 "]" p:80 => multidia n p
 
 end LO.StandardModalLogicalConnective
 
@@ -185,25 +185,25 @@ variable [LO.StandardModalLogicalConnective F] [DecidableEq F]
 namespace Set
 
 abbrev multibox (n : ℕ) (s : Set F) : Set F := Set.multimop true n s
-notation "□[" n:90 "]" s:80 => Set.multibox n s
+notation "□^[" n:90 "]" s:80 => Set.multibox n s
 
 abbrev box (s : Set F) : Set F := Set.mop true s
 notation "□" s:80 => Set.box s
 
 abbrev premultibox (n : ℕ) (s : Set F) : Set F := Set.premultimop true n s
-notation "□⁻¹[" n:90 "]" s:80 => Set.premultibox n s
+notation "□⁻¹^[" n:90 "]" s:80 => Set.premultibox n s
 
 abbrev prebox (s : Set F) : Set F := Set.premop true s
 notation "□⁻¹" s:80 => Set.prebox s
 
 abbrev multidia (n : ℕ) (s : Set F) : Set F := Set.multimop false n s
-notation "◇[" n:90 "]" s:80 => Set.multidia n s
+notation "◇^[" n:90 "]" s:80 => Set.multidia n s
 
 abbrev dia (s : Set F) : Set F := Set.mop false s
 notation "◇" s:80 => Set.dia s
 
 abbrev premultidia (n : ℕ) (s : Set F) : Set F := Set.premultimop false n s
-notation "◇⁻¹[" n:90 "]" s:80 => Set.premultidia n s
+notation "◇⁻¹^[" n:90 "]" s:80 => Set.premultidia n s
 
 abbrev predia (s : Set F) : Set F := Set.premop false s
 notation "◇⁻¹" s:80 => Set.predia s
@@ -227,25 +227,25 @@ end List
 namespace Finset
 
 noncomputable abbrev multibox (n : ℕ) (s : Finset F) : Finset F := Finset.multimop true n s
-notation "□[" n:90 "]" s:80 => Finset.multibox n s
+notation "□^[" n:90 "]" s:80 => Finset.multibox n s
 
 noncomputable abbrev box (s : Finset F) : Finset F := Finset.mop true s
 notation "□" s:80 => Finset.box s
 
 noncomputable abbrev premultibox (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop true n s
-notation "□⁻¹[" n:90 "]" s:80 => Finset.premultibox n s
+notation "□⁻¹^[" n:90 "]" s:80 => Finset.premultibox n s
 
 noncomputable abbrev prebox (s : Finset F) : Finset F := Finset.premop true s
 notation "□⁻¹" s:80 => Finset.prebox s
 
 noncomputable abbrev multidia (n : ℕ) (s : Finset F) : Finset F := Finset.multimop false n s
-notation "◇[" n:90 "]" s:80 => Finset.multidia n s
+notation "◇^[" n:90 "]" s:80 => Finset.multidia n s
 
 noncomputable abbrev dia (s : Finset F) : Finset F := Finset.mop false s
 notation "◇" s:80 => Finset.dia s
 
 noncomputable abbrev premultidia (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop false n s
-notation "◇⁻¹[" n:90 "]" s:80 => Finset.premultidia n s
+notation "◇⁻¹^[" n:90 "]" s:80 => Finset.premultidia n s
 
 noncomputable abbrev predia (s : Finset F) : Finset F := Finset.premop false s
 notation "◇⁻¹" s:80 => Finset.predia s

--- a/Logic/Modal/LogicSymbol.lean
+++ b/Logic/Modal/LogicSymbol.lean
@@ -1,15 +1,13 @@
- import Logic.Logic.LogicSymbol
+import Logic.Logic.LogicSymbol
 
 namespace LO
 
-/--
-  Finite many unary modal operators
--/
 class UnaryModalOperator (ι : Type*) (F : Sort*) where
   mop (i : ι) : F → F
   mop_injective {i} : Function.Injective (mop i)
 
 notation:76 "△[" i "]" p => UnaryModalOperator.mop i p
+
 
 namespace UnaryModalOperator
 
@@ -39,21 +37,17 @@ end UnaryModalOperator
 
 end LO
 
-/-
-TODO: 可算無限個の様相演算子を考えたいのならば以下の定義を用意すればよいと思うが，現状では考えていないので保留
 
-class InfiniteUnaryModalOperator (F : Sort _) where
-  mop (i : ℕ) : F → F
-  mop_injective {i} : Function.Injective (mop i)
--/
+section
+
+open LO UnaryModalOperator
+
+variable [UnaryModalOperator ι F] [DecidableEq F]
+variable {i : ι} {n : ℕ} {a : F}
 
 namespace Set
 
-open LO
-open UnaryModalOperator
-
-variable [UnaryModalOperator ι F]
-variable {i : ι} {s t : Set F} {n : ℕ} {a : F}
+variable {s t : Set F}
 
 protected def multimop (i : ι) (n : ℕ) (s : Set F) : Set F := (multimop i n) '' s
 notation:76 "△[" i:90 "]" "[" n:90 "]" s:max => Set.multimop i n s
@@ -157,8 +151,7 @@ namespace List
 open LO
 open UnaryModalOperator
 
-variable [UnaryModalOperator ι F] [DecidableEq F]
-variable {i : ι} {n : ℕ} {l : List F}
+variable {l : List F}
 
 @[simp] protected def multimop (i : ι) (n : ℕ) (l : List F) : List F := l.map (multimop i n)
 notation "△[" i:90 "]" "[" n:90 "]" l:max => List.multimop i n l
@@ -181,11 +174,7 @@ end List
 
 namespace Finset
 
-open LO
-open UnaryModalOperator
-
-variable [UnaryModalOperator ι F] [DecidableEq F]
-variable {i : ι} {n : ℕ} {s t : Finset F}
+variable {s t : Finset F}
 
 @[simp] protected noncomputable def multimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := (△[i][n](s.toList)).toFinset
 notation "△[" i:90 "]" "[" n:90 "]" s:max => Finset.multimop i n s
@@ -224,6 +213,9 @@ lemma premultimop_multimop_eq_of_subset_multimop {s : Finset F} {t : Set F} (hs 
 
 end Finset
 
+end
+
+
 namespace LO
 
 /--
@@ -234,7 +226,7 @@ class StandardModalLogicalConnective (F : Sort _) extends LogicalConnective F, U
 
 namespace StandardModalLogicalConnective
 
-variable [hS : StandardModalLogicalConnective F] [DecidableEq F]
+variable [StandardModalLogicalConnective F] [DecidableEq F]
 
 @[match_pattern]
 abbrev box : F → F := UnaryModalOperator.mop true
@@ -244,7 +236,7 @@ prefix:74 "□" => StandardModalLogicalConnective.box
 abbrev dia : F → F := UnaryModalOperator.mop false
 prefix:74 "◇" => StandardModalLogicalConnective.dia
 
-lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply hS.duality
+lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply StandardModalLogicalConnective.duality
 
 abbrev multibox (n : ℕ) : F → F := UnaryModalOperator.multimop true n
 notation:74 "□[" n:90 "]" p:80 => StandardModalLogicalConnective.multibox n p

--- a/Logic/Modal/LogicSymbol.lean
+++ b/Logic/Modal/LogicSymbol.lean
@@ -1,37 +1,37 @@
 import Logic.Logic.LogicSymbol
 
+open Function
+
 namespace LO
 
-class UnaryModalOperator (ι : Type*) (F : Sort*) where
+class UnaryModalOperator (ι : Type*) (F : Type*) where
   mop (i : ι) : F → F
   mop_injective {i} : Function.Injective (mop i)
 
-notation:76 "△[" i "]" p => UnaryModalOperator.mop i p
-
+attribute [simp] UnaryModalOperator.mop_injective
 
 namespace UnaryModalOperator
 
 variable [UnaryModalOperator ι F]
 variable {i : ι} {p q : F}
 
-@[simp] lemma mop_injective' : (△[i]p) = (△[i]q) ↔ p = q := by constructor; intro h; exact mop_injective h; simp_all;
+@[simp] lemma mop_injective' : ((mop i) p) = ((mop i) q) ↔ p = q := by constructor; intro h; exact mop_injective h; simp_all;
 
-def multimop (i : ι) (n : ℕ) (p : F) : F :=
-  match n with
-  | 0 => p
-  | n + 1 => △[i]((multimop i n p))
+@[simp] def multimop (i : ι) (n : ℕ) (p : F) : F := Nat.iterate (mop i) n p
 
-notation:76 "△[" i:90 "]" "[" n:90 "]" p:max => multimop i n p
+@[simp] lemma multimop_zero : (mop i)^[0] p = p := rfl
 
-@[simp] lemma multimop_zero : △[i][0]p = p := rfl
+@[simp] lemma mzero : multimop i 0 = (id : F → F) := rfl
 
-@[simp] lemma multimop_succ : △[i][(n + 1)]p = △[i](△[i][n]p) := rfl
+lemma multimop_succ : (mop i)^[(n + 1)] p = (mop i)^[n] ((mop i) p) := by apply iterate_succ_apply
 
-lemma multimop_prepost : (△[i]△[i][n]p) = (△[i][n](△[i]p)) := by induction n <;> simp_all
+@[simp] lemma multimop_succ' : (mop i)^[(n + 1)] p = (mop i) ((mop i)^[n] p) := by apply iterate_succ_apply'
 
-@[simp] lemma multimop_injective' : (△[i][n]p = △[i][n]q) ↔ (p = q) := by induction n <;> simp [*]
+lemma multimop_prepost : ((mop i) ((mop i)^[n] p)) = ((mop i)^[n] ((mop i) p)) := by induction n <;> simp_all
 
-@[simp] lemma multimop_injective : Function.Injective ((△[i][n]·) : F → F) := by simp [Function.Injective];
+@[simp] lemma multimop_injective' : ((mop i)^[n] p = (mop i)^[n] q) ↔ (p = q) := by induction n <;> simp [*]
+
+@[simp] lemma multimop_injective : Function.Injective (((mop i)^[n]) : F → F) := by apply Function.Injective.iterate (by simp);
 
 end UnaryModalOperator
 
@@ -54,11 +54,11 @@ notation:76 "△[" i:90 "]" "[" n:90 "]" s:max => Set.multimop i n s
 
 @[simp] lemma multimop_empty : △[i][n](∅ : Set F) = ∅ := by simp [Set.multimop]
 
-@[simp] lemma multimop_singleton : △[i][n]({a} : Set F) = {△[i][n]a} := by simp [Set.multimop]
+@[simp] lemma multimop_singleton : △[i][n]({a} : Set F) = {(mop i)^[n] a} := by simp [Set.multimop]
 
 @[simp] lemma multimop_zero : △[i][0]s = s := by simp [Set.multimop]
 
-@[simp] lemma multimop_mem_intro : a ∈ s → △[i][n]a ∈ (△[i][n]s) := by tauto;
+@[simp] lemma multimop_mem_intro : a ∈ s → (mop i)^[n] a ∈ (△[i][n]s) := by tauto;
 
 @[simp] lemma multimop_injOn : Set.InjOn (multimop i n) (multimop i n ⁻¹' s) := by simp [Set.InjOn];
 
@@ -66,9 +66,9 @@ notation:76 "△[" i:90 "]" "[" n:90 "]" s:max => Set.multimop i n s
 
 @[simp] lemma multimop_union : (△[i][n](s ∪ t)) = (△[i][n]s) ∪ (△[i][n]t) := by simp_all [Set.image_union, Set.multimop];
 
-lemma multimop_mem_iff : a ∈ (△[i][n]s) ↔ (∃ b ∈ s, △[i][n]b = a) := by simp_all [Set.mem_image, Set.multimop];
+lemma multimop_mem_iff : a ∈ (△[i][n]s) ↔ (∃ b ∈ s, (mop i)^[n] b = a) := by simp_all [Set.mem_image, Set.multimop];
 
-lemma forall_multimop_of_subset_multimop (h : s ⊆ △[i][n]t) : ∀ p ∈ s, ∃ q ∈ t, p = △[i][n]q := by
+lemma forall_multimop_of_subset_multimop (h : s ⊆ △[i][n]t) : ∀ p ∈ s, ∃ q ∈ t, p = (mop i)^[n] q := by
   intro p hp;
   obtain ⟨q, hq₁, hq₂⟩ := h hp;
   use q;
@@ -79,9 +79,9 @@ notation:76 "△[" i "]" s => Set.mop i s
 
 @[simp] lemma mop_empty : (△[i](∅ : Set F)) = ∅ := by simp [Set.mop]
 
-@[simp] lemma mop_singleton : (△[i]({a} : Set F)) = {△[i]a} := by simp [Set.mop]
+@[simp] lemma mop_singleton : (△[i]({a} : Set F)) = {(mop i a)} := by simp [Set.mop]
 
-@[simp] lemma mop_mem_intro : a ∈ s → (△[i]a) ∈ (△[i]s) := by apply multimop_mem_intro;
+@[simp] lemma mop_mem_intro : a ∈ s → (mop i a) ∈ (△[i]s) := by apply multimop_mem_intro;
 
 @[simp] lemma mop_injOn : Set.InjOn (multimop i n) s := by simp [Set.InjOn]
 
@@ -89,11 +89,11 @@ lemma mop_subset (h : s ⊆ t) : (△[i]s) ⊆ (△[i]t) := by apply multimop_su
 
 @[simp] lemma mop_union : (△[i](s ∪ t)) = (△[i]s) ∪ (△[i]t) := by apply multimop_union;
 
-lemma mop_mem_iff : p ∈ (△[i]s) ↔ (∃ q ∈ s, (△[i]q) = p) := by apply multimop_mem_iff;
+lemma mop_mem_iff : p ∈ (△[i]s) ↔ (∃ q ∈ s, (mop i q) = p) := by apply multimop_mem_iff;
 
 protected lemma mop_injective : Function.Injective (λ {s : Set F} => Set.mop i s) := Function.Injective.image_injective mop_injective
 
-lemma forall_mop_of_subset_mop (h : s ⊆ (Set.mop i t)) : ∀ p ∈ s, ∃ q ∈ t, p = △[i]q := forall_multimop_of_subset_multimop h
+lemma forall_mop_of_subset_mop (h : s ⊆ (Set.mop i t)) : ∀ p ∈ s, ∃ q ∈ t, p = mop i q := forall_multimop_of_subset_multimop h
 
 
 @[simp] protected def premultimop (i : ι) (n : ℕ) (s : Set F) := (multimop i n) ⁻¹' s
@@ -111,6 +111,7 @@ lemma premultimop_multimop_eq_of_subset_premultimop (hs : s ⊆ △[i][n]t) : �
   . intro p hp;
     obtain ⟨q, _, hq₂⟩ := forall_multimop_of_subset_multimop hs p hp;
     simp_all [multimop, Set.premultimop];
+
 
 @[simp] lemma premultimop_multimop_subset : △[i][n](△⁻¹[i][n]s) ⊆ s := by simp [Set.subset_def, Set.multimop, Set.premultimop];
 
@@ -153,7 +154,7 @@ open UnaryModalOperator
 
 variable {l : List F}
 
-@[simp] protected def multimop (i : ι) (n : ℕ) (l : List F) : List F := l.map (multimop i n)
+protected abbrev multimop (i : ι) (n : ℕ) (l : List F) : List F := l.map (multimop i n)
 notation "△[" i:90 "]" "[" n:90 "]" l:max => List.multimop i n l
 
 @[simp] protected def mop (i : ι) (l : List F) : List F := △[i][1]l
@@ -161,9 +162,9 @@ notation "△[" n:90 "]" l:max => List.mop n l
 
 @[simp] lemma multimop_empty : △[i][n]([] : List F) = [] := by simp [List.multimop]
 
-@[simp] lemma multimop_zero : △[i][0]l = l := by simp [List.multimop, multimop]
+@[simp] protected lemma multimop_zero : △[i][0]l = l := by simp [List.multimop, multimop, multimop_zero]
 
-def premultimop (i : ι) (n : ℕ) (l : List F) := l.filter (λ (p : F) => △[i][n]p ∈ l)
+def premultimop (i : ι) (n : ℕ) (l : List F) := l.filter (λ (p : F) => (mop i)^[n] p ∈ l)
 notation "△⁻¹[" i:90 "]" "[" n:90 "]" l:max => List.premultimop i n l
 
 @[simp] def premop (i : ι) (l : List F) := △[i][1]l
@@ -186,7 +187,7 @@ lemma multimop_def : (△[i][n]s : Finset F) = s.image (multimop i n) := by simp
 
 lemma multimop_coe : ↑(△[i][n]s : Finset F) = △[i][n](↑s : Set F) := by simp_all [Set.multimop, List.multimop]; rfl;
 
-@[simp] lemma multimop_zero : (△[i][0]s : Finset F) = s := by simp [-List.multimop]
+@[simp] lemma multimop_zero : (△[i][0]s : Finset F) = s := by simp
 
 @[simp]
 lemma multimop_union : (△[i][n](s ∪ t) : Finset F) = (△[i][n]s ∪ △[i][n]t : Finset F) := by
@@ -218,6 +219,8 @@ end
 
 namespace LO
 
+open UnaryModalOperator
+
 /--
   Standard modal logic, which has 2 modal unary operators `□`, `◇`, and `◇` is defined as dual of `□`
 -/
@@ -229,19 +232,19 @@ namespace StandardModalLogicalConnective
 variable [StandardModalLogicalConnective F] [DecidableEq F]
 
 @[match_pattern]
-abbrev box : F → F := UnaryModalOperator.mop true
+abbrev box : F → F := mop true
 prefix:74 "□" => StandardModalLogicalConnective.box
 
 @[match_pattern]
-abbrev dia : F → F := UnaryModalOperator.mop false
+abbrev dia : F → F := mop false
 prefix:74 "◇" => StandardModalLogicalConnective.dia
 
 lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply StandardModalLogicalConnective.duality
 
-abbrev multibox (n : ℕ) : F → F := UnaryModalOperator.multimop true n
+abbrev multibox (n : ℕ) : F → F := (mop true)^[n]
 notation:74 "□[" n:90 "]" p:80 => StandardModalLogicalConnective.multibox n p
 
-abbrev multidia (n : ℕ) : F → F := UnaryModalOperator.multimop false n
+abbrev multidia (n : ℕ) : F → F := (mop false)^[n]
 notation:74 "◇[" n:90 "]" p:80 => StandardModalLogicalConnective.multidia n p
 
 end LO.StandardModalLogicalConnective

--- a/Logic/Modal/LogicSymbol.lean
+++ b/Logic/Modal/LogicSymbol.lean
@@ -17,11 +17,7 @@ variable {i : ι} {p q : F}
 
 @[simp] lemma mop_injective' : ((mop i) p) = ((mop i) q) ↔ p = q := by constructor; intro h; exact mop_injective h; simp_all;
 
-@[simp] def multimop (i : ι) (n : ℕ) (p : F) : F := Nat.iterate (mop i) n p
-
 @[simp] lemma multimop_zero : (mop i)^[0] p = p := rfl
-
-@[simp] lemma mzero : multimop i 0 = (id : F → F) := rfl
 
 lemma multimop_succ : (mop i)^[(n + 1)] p = (mop i)^[n] ((mop i) p) := by apply iterate_succ_apply
 
@@ -49,100 +45,73 @@ namespace Set
 
 variable {s t : Set F}
 
-protected def multimop (i : ι) (n : ℕ) (s : Set F) : Set F := (multimop i n) '' s
-notation:76 "△[" i:90 "]" "[" n:90 "]" s:max => Set.multimop i n s
+protected abbrev mop (i : ι) : Set F → Set F := image (mop i)
 
-@[simp] lemma multimop_empty : △[i][n](∅ : Set F) = ∅ := by simp [Set.multimop]
+protected abbrev multimop (i : ι) (n : ℕ) : Set F → Set F := image (mop i)^[n]
 
-@[simp] lemma multimop_singleton : △[i][n]({a} : Set F) = {(mop i)^[n] a} := by simp [Set.multimop]
+@[simp] lemma mop_iff_multimop_one : (Set.mop i s) = (Set.multimop i 1 s) := by rfl
 
-@[simp] lemma multimop_zero : △[i][0]s = s := by simp [Set.multimop]
 
-@[simp] lemma multimop_mem_intro : a ∈ s → (mop i)^[n] a ∈ (△[i][n]s) := by tauto;
+protected abbrev premultimop (i : ι) (n : ℕ) : Set F → Set F := Set.preimage ((mop i)^[n])
 
-@[simp] lemma multimop_injOn : Set.InjOn (multimop i n) (multimop i n ⁻¹' s) := by simp [Set.InjOn];
+protected abbrev premop (i : ι) : Set F → Set F := Set.premultimop i 1
 
-@[simp] lemma multimop_subset (h : s ⊆ t) : (△[i][n]s) ⊆ (△[i][n]t) := by simp_all [Set.subset_def, Set.multimop];
+@[simp] lemma premop_iff_premultimop_one : (Set.premop i s) = (Set.premultimop i 1 s) := by rfl
 
-@[simp] lemma multimop_union : (△[i][n](s ∪ t)) = (△[i][n]s) ∪ (△[i][n]t) := by simp_all [Set.image_union, Set.multimop];
 
-lemma multimop_mem_iff : a ∈ (△[i][n]s) ↔ (∃ b ∈ s, (mop i)^[n] b = a) := by simp_all [Set.mem_image, Set.multimop];
+@[simp] lemma multimop_subset (h : s ⊆ t) : (Set.multimop i n s) ⊆ (Set.multimop i n t) := by simp_all [Set.subset_def];
 
-lemma forall_multimop_of_subset_multimop (h : s ⊆ △[i][n]t) : ∀ p ∈ s, ∃ q ∈ t, p = (mop i)^[n] q := by
+lemma multimop_mem_iff : a ∈ (Set.multimop i n s) ↔ (∃ b ∈ s, (mop i)^[n] b = a) := by simp_all [Set.mem_image, Set.multimop];
+
+lemma forall_multimop_of_subset_multimop (h : s ⊆ Set.multimop i n t) : ∀ p ∈ s, ∃ q ∈ t, p = (mop i)^[n] q := by
   intro p hp;
   obtain ⟨q, hq₁, hq₂⟩ := h hp;
   use q;
   simp_all;
 
-protected def mop (i : ι) (s : Set F) : Set F := Set.multimop i 1 s
-notation:76 "△[" i "]" s => Set.mop i s
-
-@[simp] lemma mop_empty : (△[i](∅ : Set F)) = ∅ := by simp [Set.mop]
-
-@[simp] lemma mop_singleton : (△[i]({a} : Set F)) = {(mop i a)} := by simp [Set.mop]
-
-@[simp] lemma mop_mem_intro : a ∈ s → (mop i a) ∈ (△[i]s) := by apply multimop_mem_intro;
-
-@[simp] lemma mop_injOn : Set.InjOn (multimop i n) s := by simp [Set.InjOn]
-
-lemma mop_subset (h : s ⊆ t) : (△[i]s) ⊆ (△[i]t) := by apply multimop_subset; assumption;
-
-@[simp] lemma mop_union : (△[i](s ∪ t)) = (△[i]s) ∪ (△[i]t) := by apply multimop_union;
-
-lemma mop_mem_iff : p ∈ (△[i]s) ↔ (∃ q ∈ s, (mop i q) = p) := by apply multimop_mem_iff;
-
 protected lemma mop_injective : Function.Injective (λ {s : Set F} => Set.mop i s) := Function.Injective.image_injective mop_injective
 
-lemma forall_mop_of_subset_mop (h : s ⊆ (Set.mop i t)) : ∀ p ∈ s, ∃ q ∈ t, p = mop i q := forall_multimop_of_subset_multimop h
+lemma forall_mop_of_subset_mop (h : s ⊆ (Set.mop i t)) : ∀ p ∈ s, ∃ q ∈ t, p = mop i q := forall_multimop_of_subset_multimop (by simpa using h)
 
 
-@[simp] protected def premultimop (i : ι) (n : ℕ) (s : Set F) := (multimop i n) ⁻¹' s
-notation:76 "△⁻¹[" i:90 "]" "[" n:90 "]" s:max => Set.premultimop i n s
 
-lemma multimop_premultimop_eq : △⁻¹[i][n](△[i][n]s) = s := by
+lemma multimop_premultimop_eq : (Set.premultimop i n) (Set.multimop i n s) = s := by
   apply Set.preimage_image_eq;
   exact multimop_injective;
 
-lemma premultimop_multimop_eq_of_subset_premultimop (hs : s ⊆ △[i][n]t) : △[i][n](△⁻¹[i][n]s) = s := by
+lemma premultimop_multimop_eq_of_subset_premultimop (hs : s ⊆ Set.multimop i n t) : Set.multimop i n ((Set.premultimop i n) s) = s := by
   apply Set.eq_of_subset_of_subset;
   . intro p hp;
     obtain ⟨q, hq₁, hq₂⟩ := hp;
     simp_all [Set.premultimop];
   . intro p hp;
     obtain ⟨q, _, hq₂⟩ := forall_multimop_of_subset_multimop hs p hp;
-    simp_all [multimop, Set.premultimop];
+    simp_all [Set.premultimop];
 
 
-@[simp] lemma premultimop_multimop_subset : △[i][n](△⁻¹[i][n]s) ⊆ s := by simp [Set.subset_def, Set.multimop, Set.premultimop];
 
-lemma premultimop_subset (h : s ⊆ t) : (△⁻¹[i][n]s) ⊆ (△⁻¹[i][n]t) := by simp_all [Set.subset_def, Set.premultimop];
+lemma premultimop_subset (h : s ⊆ t) : ((Set.premultimop i n) s) ⊆ ((Set.premultimop i n) t) := by simp_all [Set.subset_def];
 
-lemma subset_premulitimop_iff_multimop_subset (h : s ⊆ △⁻¹[i][n]t) : △[i][n]s ⊆ t := by
+lemma subset_premulitimop_iff_multimop_subset (h : s ⊆ (Set.premultimop i n) t) : Set.multimop i n s ⊆ t := by
   intro p hp;
   obtain ⟨_, h₁, h₂⟩ := multimop_subset h hp;
   subst h₂;
   assumption;
 
-lemma subset_multimop_iff_premulitimop_subset (h : s ⊆ (△[i][n]t)) : (△⁻¹[i][n]s) ⊆ t := by
+lemma subset_multimop_iff_premulitimop_subset (h : s ⊆ (Set.multimop i n t)) : ((Set.premultimop i n) s) ⊆ t := by
   intro p hp;
   obtain ⟨_, h₁, h₂⟩ := premultimop_subset h hp;
   simp_all;
 
+@[simp] lemma mop_premop_eq : (Set.premop i $ Set.mop i s) = s := by apply multimop_premultimop_eq;
 
-protected def premop (i : ι) (s : Set F) := Set.premultimop i 1 s
-notation:76 "△⁻¹[" i "]" s => Set.premop i s
+lemma premop_mop_eq_of_subset_mop (hs : s ⊆ (Set.mop i t)) : (Set.mop i $ Set.premop i s) = s := premultimop_multimop_eq_of_subset_premultimop hs
 
-@[simp] lemma mop_premop_eq : (△⁻¹[i]△[i]s) = s := by apply multimop_premultimop_eq;
+lemma premop_subset (h : s ⊆ t) : (Set.premop i s) ⊆ (Set.premop i t) := premultimop_subset h
 
-lemma premop_mop_eq_of_subset_mop (hs : s ⊆ △[i]t) : (△[i]△⁻¹[i]s) = s := premultimop_multimop_eq_of_subset_premultimop hs
+lemma subset_premop_iff_mop_subset (h : s ⊆ Set.premop i t) : (Set.mop i s) ⊆ t := subset_premulitimop_iff_multimop_subset h
 
-@[simp] lemma premop_mop_subset : (△[i]△⁻¹[i]s) ⊆ s := by apply premultimop_multimop_subset;
-
-lemma premop_subset (h : s ⊆ t) : (△⁻¹[i]s) ⊆ (△⁻¹[i]t) := premultimop_subset h
-
-lemma subset_premop_iff_mop_subset (h : s ⊆ △⁻¹[i]t) : (△[i]s) ⊆ t := subset_premulitimop_iff_multimop_subset h
-
-lemma subset_mop_iff_premop_subset (h : s ⊆ △[i]t) : (△⁻¹[i]s) ⊆ t := subset_multimop_iff_premulitimop_subset h
+lemma subset_mop_iff_premop_subset (h : s ⊆ Set.mop i t) : (Set.premop i s) ⊆ t := subset_multimop_iff_premulitimop_subset h
 
 end Set
 
@@ -154,21 +123,13 @@ open UnaryModalOperator
 
 variable {l : List F}
 
-protected abbrev multimop (i : ι) (n : ℕ) (l : List F) : List F := l.map (multimop i n)
-notation "△[" i:90 "]" "[" n:90 "]" l:max => List.multimop i n l
+protected abbrev mop (i : ι) : List F → List F := List.map (mop i)
 
-@[simp] protected def mop (i : ι) (l : List F) : List F := △[i][1]l
-notation "△[" n:90 "]" l:max => List.mop n l
+protected abbrev multimop (i : ι) (n : ℕ) : List F → List F := List.map ((mop i)^[n])
 
-@[simp] lemma multimop_empty : △[i][n]([] : List F) = [] := by simp [List.multimop]
+protected abbrev premultimop (i : ι) (n : ℕ) := List.filter (λ (p : F) => (mop i)^[n] p ∈ l)
 
-@[simp] protected lemma multimop_zero : △[i][0]l = l := by simp [List.multimop, multimop, multimop_zero]
-
-def premultimop (i : ι) (n : ℕ) (l : List F) := l.filter (λ (p : F) => (mop i)^[n] p ∈ l)
-notation "△⁻¹[" i:90 "]" "[" n:90 "]" l:max => List.premultimop i n l
-
-@[simp] def premop (i : ι) (l : List F) := △[i][1]l
-notation "△⁻¹[" i:90 "]" l:max => List.premop i l
+protected abbrev premop (i : ι) (l : List F) := l.filter (λ (p : F) => (mop i) p ∈ l)
 
 end List
 
@@ -177,37 +138,29 @@ namespace Finset
 
 variable {s t : Finset F}
 
-@[simp] protected noncomputable def multimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := (△[i][n](s.toList)).toFinset
-notation "△[" i:90 "]" "[" n:90 "]" s:max => Finset.multimop i n s
+protected noncomputable abbrev multimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := (s.toList).multimop i n |>.toFinset
 
-@[simp] protected noncomputable def mop (i : ι) (s : Finset F) : Finset F := △[i][1]s
-notation "△[" i:90 "]" s:max => Finset.mop i s
+protected noncomputable abbrev mop (i : ι) (s : Finset F) : Finset F := (s.toList).multimop i 1 |>.toFinset
 
-lemma multimop_def : (△[i][n]s : Finset F) = s.image (multimop i n) := by simp [List.multimop, List.toFinset_map];
+protected noncomputable abbrev premultimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := s.preimage ((mop i)^[n]) (by simp [Set.InjOn])
 
-lemma multimop_coe : ↑(△[i][n]s : Finset F) = △[i][n](↑s : Set F) := by simp_all [Set.multimop, List.multimop]; rfl;
+protected noncomputable abbrev premop (i : ι) (s : Finset F) : Finset F := s.premultimop i 1
 
-@[simp] lemma multimop_zero : (△[i][0]s : Finset F) = s := by simp
+lemma multimop_coe : ↑(Finset.multimop i n s : Finset F) = Set.multimop i n (↑s : Set F) := by simp_all [Set.multimop, List.multimop]; rfl;
 
 @[simp]
-lemma multimop_union : (△[i][n](s ∪ t) : Finset F) = (△[i][n]s ∪ △[i][n]t : Finset F) := by
-  simp [List.toFinset_map, List.multimop];
+lemma multimop_union : (Finset.multimop i n (s ∪ t) : Finset F) = (Finset.multimop i n s ∪ Finset.multimop i n t) := by
+  simp [List.toFinset_map];
   aesop;
 
 lemma multimop_mem_coe {s : Finset F} : a ∈ Finset.multimop i n s ↔ a ∈ Set.multimop i n (↑s : Set F) := by
   constructor <;> simp_all [Set.multimop];
 
-@[simp] noncomputable def premultimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := s.preimage (multimop i n) (by simp)
-notation "△⁻¹[" i:90 "]" "[" n:90 "]" s:max => Finset.premultimop i n s
+lemma premultimop_coe : ↑(s.premultimop i n) = (↑s : Set F).premultimop i n := by apply Finset.coe_preimage;
 
-@[simp] noncomputable def premop (i : ι) (s : Finset F) : Finset F := △⁻¹[i][1]s
-notation "△⁻¹[" i:90 "]" s:max => Finset.premop i s
+lemma premop_coe : ↑(s.premop i) = (↑s : Set F).premop i := by apply premultimop_coe;
 
-lemma premultimop_coe : ↑(△⁻¹[i][n]s : Finset F) = △⁻¹[i][n](↑s : Set F) := by apply Finset.coe_preimage;
-
-lemma premop_coe : ↑(△⁻¹[i]s : Finset F) = △⁻¹[i](↑s : Set F) := by apply premultimop_coe;
-
-lemma premultimop_multimop_eq_of_subset_multimop {s : Finset F} {t : Set F} (hs : ↑s ⊆ △[i][n]t) : (△[i][n](△⁻¹[i][n]s : Finset F) : Finset F) = s := by
+lemma premultimop_multimop_eq_of_subset_multimop {s : Finset F} {t : Set F} (hs : ↑s ⊆ Set.multimop i n t) : (s.premultimop i n).multimop i n = s := by
   have := Set.premultimop_multimop_eq_of_subset_premultimop hs;
   rw [←premultimop_coe, ←multimop_coe] at this;
   exact Finset.coe_inj.mp this;

--- a/Logic/Modal/Normal.lean
+++ b/Logic/Modal/Normal.lean
@@ -1,4 +1,3 @@
-import Logic.Modal.Normal.LogicSymbol
 import Logic.Modal.Normal.Formula
 import Logic.Modal.Normal.Axioms
 import Logic.Modal.Normal.HilbertStyle

--- a/Logic/Modal/Normal/Axioms.lean
+++ b/Logic/Modal/Normal/Axioms.lean
@@ -34,7 +34,7 @@ namespace LO.Modal.Normal
 
 section Axioms
 
-variable {F : Type u} [ModalLogicSymbol F] (p q : F)
+variable {F : Type u} [StandardModalLogicalConnective F] (p q : F)
 
 /-- a.k.a. Distribution Axiom -/
 abbrev axiomK := □(p ⟶ q) ⟶ □p ⟶ □q

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -420,7 +420,7 @@ lemma context_box_conj_membership_iff {Δ : Context β} : □(⋀Δ) ∈ Ω ↔ 
     exact box_finset_conj_iff!.mpr h;
 
 lemma context_box_conj_membership_iff' {Δ : Context β} : □(⋀Δ) ∈ Ω ↔ (∀ p ∈ (□Δ : Context β), p ∈ Ω) := by
-  simp [Context.box, Finset.box, List.multibox];
+  simp [Finset.box, List.multibox];
   apply context_box_conj_membership_iff hK;
 
 lemma context_multibox_conj_membership_iff {Δ : Context β} {n : ℕ} : □[n](⋀Δ) ∈ Ω ↔ (∀ p ∈ Δ, □[n]p ∈ Ω) := by
@@ -435,7 +435,7 @@ lemma context_multibox_conj_membership_iff {Δ : Context β} {n : ℕ} : □[n](
     exact multibox_finset_conj_iff!.mpr h;
 
 lemma context_multibox_conj_membership_iff' {Δ : Context β} : □[n](⋀Δ) ∈ Ω ↔ (∀ p ∈ (□[n]Δ : Context β), p ∈ Ω):= by
-  simp [Context.multibox, Finset.multibox, List.multibox];
+  simp [Finset.multibox, List.multibox];
   apply context_multibox_conj_membership_iff hK;
 
 end MaximalConsistentTheory
@@ -509,8 +509,8 @@ lemma frame_def': (CanonicalModel Λ).frame Ω₁ Ω₂ ↔ (◇Ω₂ ⊆ Ω₁.
   simp only [frame_def];
   constructor;
   . intro h p hp;
-    have ⟨q, hq₁, hq₂⟩ := Set.dia_mem_iff.mp hp;
-    rw [←hq₂, ModalDuality.dia_to_box];
+    have ⟨q, hq₁, hq₂⟩ := mop_mem_iff.mp hp;
+    rw [←hq₂];
     apply (Ω₁.neg_membership_iff).mpr;
     by_contra hC;
     have : ~q ∈ Ω₂ := by aesop;
@@ -518,7 +518,7 @@ lemma frame_def': (CanonicalModel Λ).frame Ω₁ Ω₂ ↔ (◇Ω₂ ⊆ Ω₁.
   . intro h p;
     contrapose;
     intro hnp;
-    have : ◇(~p) ∈ Ω₁ := by simpa using h $ dia_mem_intro $ neg_membership_iff.mpr hnp;
+    have : ◇(~p) ∈ Ω₁ := by simpa using h $ mop_mem_intro $ neg_membership_iff.mpr hnp;
     have : ~(□p) ∈ Ω₁ := by
       suffices h : Ω₁.theory ⊢ᴹ[Λ]! ((◇~p) ⟷ ~(□p)) by exact MaximalConsistentTheory.iff_congr h |>.mp this;
       apply equiv_dianeg_negbox!;
@@ -544,21 +544,20 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
         by_contra hInc;
         obtain ⟨Δ₁, Δ₂, hΔ₁, hΔ₂, hUd⟩ := inconsistent_union (by simpa only [Theory.Inconsistent_iff] using hInc);
 
-        have h₁ : □⋀Δ₁ ∈ Ω₁ := by -- TODO: refactor
+        have h₁ : □⋀Δ₁ ∈ Ω₁ := by
           apply context_box_conj_membership_iff' hK |>.mpr;
-          have : □(↑Δ₁ : Theory β) ⊆ Ω₁ := subset_prebox_iff_box_subset hΔ₁;
-          simp only [←Context.box_coe_eq] at this;
+          have : □(Δ₁ : Theory β) ⊆ Ω₁ := subset_premop_iff_mop_subset hΔ₁;
           intro p hp;
-          exact this hp;
-
+          apply this;
+          sorry;
         have h₂ : ⋀(◇⁻¹[n]Δ₂) ∈ Ω₂ := by -- TODO: refactor
           apply context_conj_membership_iff.mpr;
-          have : ◇⁻¹[n](↑Δ₂ : Theory β) ⊆ Ω₂.theory := subset_multidia_iff_premulitidia_subset hΔ₂;
-          simp only [←Context.premultidia_coe_eq] at this;
+          have : ◇⁻¹[n](↑Δ₂ : Theory β) ⊆ Ω₂.theory := subset_multimop_iff_premulitimop_subset hΔ₂;
+          simp only [←premultimop_coe] at this;
           intro p hp;
           exact this hp;
 
-        have e : (◇[n](◇⁻¹[n]Δ₂) : Context β) = Δ₂ := by simpa using premultidia_multidia_eq_of_subset_multidia hΔ₂;
+        have e : (◇[n](◇⁻¹[n]Δ₂) : Context β) = Δ₂ := by simpa using premultimop_multimop_eq_of_subset_multimop hΔ₂;
 
         have : ⋀(◇⁻¹[n]Δ₂) ∉ Ω₂ := by
           have : ∅ ⊢ᴹ[Λ]! ~⋀(Δ₁ ∪ Δ₂) := by simpa [NegDefinition.neg] using finset_dt!.mp (by simpa using hUd);
@@ -586,7 +585,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
       . apply ih;
         apply (multibox_multidia hK).mpr;
         intro p hp;
-        have : ◇[n]p ∈ ◇[n]Ω₂ := Set.multidia_mem_intro hp;
+        have : ◇[n]p ∈ ◇[n]Ω₂ := multimop_mem_intro hp;
         apply hΩ;
         simp_all;
 

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -368,10 +368,6 @@ lemma multidia_dual {n : ℕ} {p : Formula β} : (◇[n]p ∈ Ω) ↔ (~(□[n](
     apply membership_iff.mpr;
     assumption;
 
-lemma multidia_prepost {n : ℕ} {p : Formula β} : (◇◇[n]p ∈ Ω) ↔ (◇[n](◇p) ∈ Ω) := by simp only [UnaryModalOperator.multimop_prepost];
-
-lemma mutlidia_prepost' {n : ℕ} {p : Formula β} : (◇[(n + 1)]p ∈ Ω) ↔ (◇[n](◇p) ∈ Ω) := by simp [UnaryModalOperator.multimop_prepost];
-
 @[simp]
 lemma no_falsum : ⊥ ∉ Ω := consistent_no_falsum Ω.consitent
 
@@ -546,7 +542,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
 
         have h₁ : □⋀Δ₁ ∈ Ω₁ := by
           apply context_box_conj_membership_iff' hK |>.mpr;
-          have : □(Δ₁ : Theory β) ⊆ Ω₁ := subset_premop_iff_mop_subset hΔ₁;
+          have : □(Δ₁ : Theory β) ⊆ Ω₁ := by simpa using subset_premulitimop_iff_multimop_subset (by simpa using hΔ₁);
           intro p hp;
           exact this $ multimop_mem_coe.mp hp;
         have h₂ : ⋀(◇⁻¹[n]Δ₂) ∈ Ω₂ := by -- TODO: refactor
@@ -556,7 +552,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
           intro p hp;
           exact this hp;
 
-        have e : (◇[n](◇⁻¹[n]Δ₂) : Context β) = Δ₂ := by simpa using premultimop_multimop_eq_of_subset_multimop hΔ₂;
+        have e : (◇[n](◇⁻¹[n]Δ₂) : Context β) = Δ₂ := premultimop_multimop_eq_of_subset_multimop hΔ₂;
 
         have : ⋀(◇⁻¹[n]Δ₂) ∉ Ω₂ := by
           have : ∅ ⊢ᴹ[Λ]! ~⋀(Δ₁ ∪ Δ₂) := by simpa [NegDefinition.neg] using finset_dt!.mp (by simpa using hUd);

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -548,8 +548,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
           apply context_box_conj_membership_iff' hK |>.mpr;
           have : □(Δ₁ : Theory β) ⊆ Ω₁ := subset_premop_iff_mop_subset hΔ₁;
           intro p hp;
-          apply this;
-          sorry;
+          exact this $ multimop_mem_coe.mp hp;
         have h₂ : ⋀(◇⁻¹[n]Δ₂) ∈ Ω₂ := by -- TODO: refactor
           apply context_conj_membership_iff.mpr;
           have : ◇⁻¹[n](↑Δ₂ : Theory β) ⊆ Ω₂.theory := subset_multimop_iff_premulitimop_subset hΔ₂;

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -569,7 +569,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
           have : ∅ ⊢ᴹ[Λ]! ⋀Δ₁ ⟶ ~(◇[n](⋀(◇⁻¹[n]Δ₂))) := imp_eq_mpr'! $ neg_conj'! (by assumption);
           have : ∅ ⊢ᴹ[Λ]! ~(◇[n](⋀(◇⁻¹[n]Δ₂))) ⟶ (□[n](~(⋀◇⁻¹[n]Δ₂))) := contra₂'! $ iff_mpr'! $ multidia_duality!;
           have : ∅ ⊢ᴹ[Λ]! ⋀Δ₁ ⟶ □[n](~⋀◇⁻¹[n]Δ₂) := imp_trans'! (by assumption) (by assumption);
-          have : Ω₁ ⊢ᴹ[Λ]! □⋀Δ₁ ⟶ □[(n + 1)](~(⋀◇⁻¹[n]Δ₂)) := box_distribute_nec'! (by assumption);
+          have : Ω₁ ⊢ᴹ[Λ]! □⋀Δ₁ ⟶ □[(n + 1)](~(⋀◇⁻¹[n]Δ₂)) := by simpa using box_distribute_nec'! this;
           have : Ω₁ ⊢ᴹ[Λ]! □[(n + 1)](~⋀◇⁻¹[n]Δ₂) := (by assumption) ⨀ (membership_iff.mp h₁);
           have : □[(n + 1)](~⋀◇⁻¹[n]Δ₂) ∈ Ω₁ := membership_iff.mpr (by assumption);
           exact neg_membership_iff.mp $ h (by assumption);

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -509,7 +509,7 @@ lemma frame_def': (CanonicalModel Λ).frame Ω₁ Ω₂ ↔ (◇Ω₂ ⊆ Ω₁.
   simp only [frame_def];
   constructor;
   . intro h p hp;
-    have ⟨q, hq₁, hq₂⟩ := mop_mem_iff.mp hp;
+    have ⟨q, hq₁, hq₂⟩ := Set.mem_image _ _ _ |>.mp hp;
     rw [←hq₂];
     apply (Ω₁.neg_membership_iff).mpr;
     by_contra hC;
@@ -518,7 +518,7 @@ lemma frame_def': (CanonicalModel Λ).frame Ω₁ Ω₂ ↔ (◇Ω₂ ⊆ Ω₁.
   . intro h p;
     contrapose;
     intro hnp;
-    have : ◇(~p) ∈ Ω₁ := by simpa using h $ mop_mem_intro $ neg_membership_iff.mpr hnp;
+    have : ◇(~p) ∈ Ω₁ := by apply h; simpa using neg_membership_iff.mpr hnp;
     have : ~(□p) ∈ Ω₁ := by
       suffices h : Ω₁.theory ⊢ᴹ[Λ]! ((◇~p) ⟷ ~(□p)) by exact MaximalConsistentTheory.iff_congr h |>.mp this;
       apply equiv_dianeg_negbox!;
@@ -584,7 +584,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
       . apply ih;
         apply (multibox_multidia hK).mpr;
         intro p hp;
-        have : ◇[n]p ∈ ◇[n]Ω₂ := multimop_mem_intro hp;
+        have : ◇[n]p ∈ ◇[n]Ω₂ := by aesop;
         apply hΩ;
         simp_all;
 

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -334,37 +334,37 @@ lemma box_dual {p : Formula β} : (□p ∈ Ω) ↔ (~(◇(~p)) ∈ Ω) := by
   . intro h;
     exact box_dn_iff hK |>.mpr $ dn_membership_iff.mpr h
 
-lemma multibox_dual {n : ℕ} {p : Formula β} : (□[n]p ∈ Ω) ↔ (~(◇[n](~p)) ∈ Ω) := by
+lemma multibox_dual {n : ℕ} {p : Formula β} : (□^[n]p ∈ Ω) ↔ (~(◇^[n](~p)) ∈ Ω) := by
   have := Deduction.ofKSubset hK;
   have := Deduction.instBoxedNecessitation hK;
 
-  have d : Ω.theory ⊢ᴹ[Λ]! □[n]p ⟷ ~(◇[n](~p)) := multibox_duality!
+  have d : Ω.theory ⊢ᴹ[Λ]! □^[n]p ⟷ ~(◇^[n](~p)) := multibox_duality!
 
   constructor;
   . intro h;
-    have : Ω.theory ⊢ᴹ[Λ]! ~(◇[n](~p)) := (iff_mp'! d) ⨀ (membership_iff.mp h);
+    have : Ω.theory ⊢ᴹ[Λ]! ~(◇^[n](~p)) := (iff_mp'! d) ⨀ (membership_iff.mp h);
     apply membership_iff.mpr;
     assumption;
   . intro h;
-    have : Ω.theory ⊢ᴹ[Λ]! □[n]p := (iff_mpr'! d) ⨀ (membership_iff.mp h);
+    have : Ω.theory ⊢ᴹ[Λ]! □^[n]p := (iff_mpr'! d) ⨀ (membership_iff.mp h);
     apply membership_iff.mpr;
     assumption;
 
 lemma dia_dual {p : Formula β} : (◇p ∈ Ω) ↔ (~(□(~p)) ∈ Ω) := by simp [StandardModalLogicalConnective.duality];
 
-lemma multidia_dual {n : ℕ} {p : Formula β} : (◇[n]p ∈ Ω) ↔ (~(□[n](~p)) ∈ Ω) := by
+lemma multidia_dual {n : ℕ} {p : Formula β} : (◇^[n]p ∈ Ω) ↔ (~(□^[n](~p)) ∈ Ω) := by
   have := Deduction.ofKSubset hK;
   have := Deduction.instBoxedNecessitation hK;
 
-  have d : Ω.theory ⊢ᴹ[Λ]! ◇[n]p ⟷ ~(□[n](~p)) := multidia_duality!
+  have d : Ω.theory ⊢ᴹ[Λ]! ◇^[n]p ⟷ ~(□^[n](~p)) := multidia_duality!
 
   constructor;
   . intro h;
-    have : Ω.theory ⊢ᴹ[Λ]! ~(□[n](~p)) := (iff_mp'! d) ⨀ membership_iff.mp h;
+    have : Ω.theory ⊢ᴹ[Λ]! ~(□^[n](~p)) := (iff_mp'! d) ⨀ membership_iff.mp h;
     apply membership_iff.mpr;
     assumption;
   . intro h;
-    have : Ω.theory ⊢ᴹ[Λ]! ◇[n]p := (iff_mpr'! d) ⨀ membership_iff.mp h;
+    have : Ω.theory ⊢ᴹ[Λ]! ◇^[n]p := (iff_mpr'! d) ⨀ membership_iff.mp h;
     apply membership_iff.mpr;
     assumption;
 
@@ -376,7 +376,7 @@ lemma neither_mem : ¬((p ∈ Ω) ∧ (~p ∈ Ω)) := by
   by_contra hC;
   exact Ω.no_falsum $ Ω.modus_ponens' hC.2 hC.1;
 
-lemma multibox_multidia {Ω₁ Ω₂ : MaximalConsistentTheory Λ} : (∀ {p : Formula β}, (□[n]p ∈ Ω₁ → p ∈ Ω₂)) ↔ (∀ {p : Formula β}, (p ∈ Ω₂ → ◇[n]p ∈ Ω₁)) := by
+lemma multibox_multidia {Ω₁ Ω₂ : MaximalConsistentTheory Λ} : (∀ {p : Formula β}, (□^[n]p ∈ Ω₁ → p ∈ Ω₂)) ↔ (∀ {p : Formula β}, (p ∈ Ω₂ → ◇^[n]p ∈ Ω₁)) := by
   constructor;
   . intro H p;
     contrapose;
@@ -419,7 +419,7 @@ lemma context_box_conj_membership_iff' {Δ : Context β} : □(⋀Δ) ∈ Ω ↔
   simp [Finset.box, List.multibox];
   apply context_box_conj_membership_iff hK;
 
-lemma context_multibox_conj_membership_iff {Δ : Context β} {n : ℕ} : □[n](⋀Δ) ∈ Ω ↔ (∀ p ∈ Δ, □[n]p ∈ Ω) := by
+lemma context_multibox_conj_membership_iff {Δ : Context β} {n : ℕ} : □^[n](⋀Δ) ∈ Ω ↔ (∀ p ∈ Δ, □^[n]p ∈ Ω) := by
   have := Deduction.ofKSubset hK;
   have := Deduction.instBoxedNecessitation hK;
 
@@ -430,7 +430,7 @@ lemma context_multibox_conj_membership_iff {Δ : Context β} {n : ℕ} : □[n](
   . intro h;
     exact multibox_finset_conj_iff!.mpr h;
 
-lemma context_multibox_conj_membership_iff' {Δ : Context β} : □[n](⋀Δ) ∈ Ω ↔ (∀ p ∈ (□[n]Δ : Context β), p ∈ Ω):= by
+lemma context_multibox_conj_membership_iff' {Δ : Context β} : □^[n](⋀Δ) ∈ Ω ↔ (∀ p ∈ (□^[n]Δ : Context β), p ∈ Ω):= by
   simp [Finset.multibox, List.multibox];
   apply context_multibox_conj_membership_iff hK;
 
@@ -521,7 +521,7 @@ lemma frame_def': (CanonicalModel Λ).frame Ω₁ Ω₂ ↔ (◇Ω₂ ⊆ Ω₁.
     have := neg_membership_iff.mp this;
     aesop;
 
-lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Formula β}, (□[n]p ∈ Ω₁ → p ∈ Ω₂)) := by
+lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Formula β}, (□^[n]p ∈ Ω₁ → p ∈ Ω₂)) := by
   have := Deduction.instBoxedNecessitation hK;
   have := Deduction.ofKSubset hK;
 
@@ -536,7 +536,7 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
     | zero => intro h; apply intro_equality; simpa;
     | succ n ih =>
       intro h;
-      obtain ⟨Ω, hΩ⟩ := exists_maximal_consistent_theory (show Consistent Λ (□⁻¹Ω₁ ∪ ◇[n]Ω₂) by
+      obtain ⟨Ω, hΩ⟩ := exists_maximal_consistent_theory (show Consistent Λ (□⁻¹Ω₁ ∪ ◇^[n]Ω₂) by
         by_contra hInc;
         obtain ⟨Δ₁, Δ₂, hΔ₁, hΔ₂, hUd⟩ := inconsistent_union (by simpa only [Theory.Inconsistent_iff] using hInc);
 
@@ -545,29 +545,29 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
           have : □(Δ₁ : Theory β) ⊆ Ω₁ := by simpa using subset_premulitimop_iff_multimop_subset (by simpa using hΔ₁);
           intro p hp;
           exact this $ multimop_mem_coe.mp hp;
-        have h₂ : ⋀(◇⁻¹[n]Δ₂) ∈ Ω₂ := by -- TODO: refactor
+        have h₂ : ⋀(◇⁻¹^[n]Δ₂) ∈ Ω₂ := by -- TODO: refactor
           apply context_conj_membership_iff.mpr;
-          have : ◇⁻¹[n](↑Δ₂ : Theory β) ⊆ Ω₂.theory := subset_multimop_iff_premulitimop_subset hΔ₂;
+          have : ◇⁻¹^[n](↑Δ₂ : Theory β) ⊆ Ω₂.theory := subset_multimop_iff_premulitimop_subset hΔ₂;
           simp only [←premultimop_coe] at this;
           intro p hp;
           exact this hp;
 
-        have e : (◇[n](◇⁻¹[n]Δ₂) : Context β) = Δ₂ := premultimop_multimop_eq_of_subset_multimop hΔ₂;
+        have e : (◇^[n](◇⁻¹^[n]Δ₂) : Context β) = Δ₂ := premultimop_multimop_eq_of_subset_multimop hΔ₂;
 
-        have : ⋀(◇⁻¹[n]Δ₂) ∉ Ω₂ := by
+        have : ⋀(◇⁻¹^[n]Δ₂) ∉ Ω₂ := by
           have : ∅ ⊢ᴹ[Λ]! ~⋀(Δ₁ ∪ Δ₂) := by simpa [NegDefinition.neg] using finset_dt!.mp (by simpa using hUd);
           have : ∅ ⊢ᴹ[Λ]! ~⋀(Δ₁ ∪ Δ₂) ⟶ ~(⋀Δ₁ ⋏ ⋀Δ₂) := contra₀'! $ iff_mpr'! $ finset_union_conj!;
           have : ∅ ⊢ᴹ[Λ]! ~(⋀Δ₁ ⋏ ⋀Δ₂) := (by assumption) ⨀ (by assumption);
-          have : ∅ ⊢ᴹ[Λ]! ◇[n](⋀◇⁻¹[n]Δ₂) ⟶ ⋀(◇[n](◇⁻¹[n]Δ₂)) := by apply distribute_multidia_finset_conj!;
-          have : ∅ ⊢ᴹ[Λ]! ◇[n](⋀◇⁻¹[n]Δ₂) ⟶ ⋀Δ₂ := by simpa only [e];
-          have : ∅ ⊢ᴹ[Λ]! ~⋀Δ₂ ⟶ ~(◇[n](⋀(◇⁻¹[n]Δ₂))) := contra₀'! (by assumption)
-          have : ∅ ⊢ᴹ[Λ]! ~(⋀Δ₁ ⋏ ◇[n](⋀(◇⁻¹[n]Δ₂))) := neg_conj_replace_right! (by assumption) (by assumption);
-          have : ∅ ⊢ᴹ[Λ]! ⋀Δ₁ ⟶ ~(◇[n](⋀(◇⁻¹[n]Δ₂))) := imp_eq_mpr'! $ neg_conj'! (by assumption);
-          have : ∅ ⊢ᴹ[Λ]! ~(◇[n](⋀(◇⁻¹[n]Δ₂))) ⟶ (□[n](~(⋀◇⁻¹[n]Δ₂))) := contra₂'! $ iff_mpr'! $ multidia_duality!;
-          have : ∅ ⊢ᴹ[Λ]! ⋀Δ₁ ⟶ □[n](~⋀◇⁻¹[n]Δ₂) := imp_trans'! (by assumption) (by assumption);
-          have : Ω₁ ⊢ᴹ[Λ]! □⋀Δ₁ ⟶ □[(n + 1)](~(⋀◇⁻¹[n]Δ₂)) := by simpa using box_distribute_nec'! this;
-          have : Ω₁ ⊢ᴹ[Λ]! □[(n + 1)](~⋀◇⁻¹[n]Δ₂) := (by assumption) ⨀ (membership_iff.mp h₁);
-          have : □[(n + 1)](~⋀◇⁻¹[n]Δ₂) ∈ Ω₁ := membership_iff.mpr (by assumption);
+          have : ∅ ⊢ᴹ[Λ]! ◇^[n](⋀◇⁻¹^[n]Δ₂) ⟶ ⋀(◇^[n](◇⁻¹^[n]Δ₂)) := by apply distribute_multidia_finset_conj!;
+          have : ∅ ⊢ᴹ[Λ]! ◇^[n](⋀◇⁻¹^[n]Δ₂) ⟶ ⋀Δ₂ := by simpa only [e];
+          have : ∅ ⊢ᴹ[Λ]! ~⋀Δ₂ ⟶ ~(◇^[n](⋀(◇⁻¹^[n]Δ₂))) := contra₀'! (by assumption)
+          have : ∅ ⊢ᴹ[Λ]! ~(⋀Δ₁ ⋏ ◇^[n](⋀(◇⁻¹^[n]Δ₂))) := neg_conj_replace_right! (by assumption) (by assumption);
+          have : ∅ ⊢ᴹ[Λ]! ⋀Δ₁ ⟶ ~(◇^[n](⋀(◇⁻¹^[n]Δ₂))) := imp_eq_mpr'! $ neg_conj'! (by assumption);
+          have : ∅ ⊢ᴹ[Λ]! ~(◇^[n](⋀(◇⁻¹^[n]Δ₂))) ⟶ (□^[n](~(⋀◇⁻¹^[n]Δ₂))) := contra₂'! $ iff_mpr'! $ multidia_duality!;
+          have : ∅ ⊢ᴹ[Λ]! ⋀Δ₁ ⟶ □^[n](~⋀◇⁻¹^[n]Δ₂) := imp_trans'! (by assumption) (by assumption);
+          have : Ω₁ ⊢ᴹ[Λ]! □⋀Δ₁ ⟶ □^[(n + 1)](~(⋀◇⁻¹^[n]Δ₂)) := by simpa using box_distribute_nec'! this;
+          have : Ω₁ ⊢ᴹ[Λ]! □^[(n + 1)](~⋀◇⁻¹^[n]Δ₂) := (by assumption) ⨀ (membership_iff.mp h₁);
+          have : □^[(n + 1)](~⋀◇⁻¹^[n]Δ₂) ∈ Ω₁ := membership_iff.mpr (by assumption);
           exact neg_membership_iff.mp $ h (by assumption);
 
         contradiction;
@@ -580,11 +580,11 @@ lemma multiframe_box : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Fo
       . apply ih;
         apply (multibox_multidia hK).mpr;
         intro p hp;
-        have : ◇[n]p ∈ ◇[n]Ω₂ := by aesop;
+        have : ◇^[n]p ∈ ◇^[n]Ω₂ := by aesop;
         apply hΩ;
         simp_all;
 
-lemma multiframe_dia : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Formula β}, (p ∈ Ω₂ → ◇[n]p ∈ Ω₁)) := Iff.trans (multiframe_box hK) (multibox_multidia hK)
+lemma multiframe_dia : (CanonicalModel Λ).frame[n] Ω₁ Ω₂ ↔ (∀ {p : Formula β}, (p ∈ Ω₂ → ◇^[n]p ∈ Ω₁)) := Iff.trans (multiframe_box hK) (multibox_multidia hK)
 
 @[simp]
 lemma val_def {a : β} : (CanonicalModel Λ).val Ω a ↔ (atom a) ∈ Ω := by rfl

--- a/Logic/Modal/Normal/Completeness.lean
+++ b/Logic/Modal/Normal/Completeness.lean
@@ -350,7 +350,7 @@ lemma multibox_dual {n : ℕ} {p : Formula β} : (□[n]p ∈ Ω) ↔ (~(◇[n](
     apply membership_iff.mpr;
     assumption;
 
-lemma dia_dual {p : Formula β} : (◇p ∈ Ω) ↔ (~(□(~p)) ∈ Ω) := by simp [ModalDuality.dia_to_box];
+lemma dia_dual {p : Formula β} : (◇p ∈ Ω) ↔ (~(□(~p)) ∈ Ω) := by simp [StandardModalLogicalConnective.duality];
 
 lemma multidia_dual {n : ℕ} {p : Formula β} : (◇[n]p ∈ Ω) ↔ (~(□[n](~p)) ∈ Ω) := by
   have := Deduction.ofKSubset hK;
@@ -368,9 +368,9 @@ lemma multidia_dual {n : ℕ} {p : Formula β} : (◇[n]p ∈ Ω) ↔ (~(□[n](
     apply membership_iff.mpr;
     assumption;
 
-lemma multidia_prepost {n : ℕ} {p : Formula β} : (◇◇[n]p ∈ Ω) ↔ (◇[n](◇p) ∈ Ω) := by simp only [Dia.multidia_prepost];
+lemma multidia_prepost {n : ℕ} {p : Formula β} : (◇◇[n]p ∈ Ω) ↔ (◇[n](◇p) ∈ Ω) := by simp only [UnaryModalOperator.multimop_prepost];
 
-lemma mutlidia_prepost' {n : ℕ} {p : Formula β} : (◇[(n + 1)]p ∈ Ω) ↔ (◇[n](◇p) ∈ Ω) := by simp [Dia.multidia_prepost];
+lemma mutlidia_prepost' {n : ℕ} {p : Formula β} : (◇[(n + 1)]p ∈ Ω) ↔ (◇[n](◇p) ∈ Ω) := by simp [UnaryModalOperator.multimop_prepost];
 
 @[simp]
 lemma no_falsum : ⊥ ∉ Ω := consistent_no_falsum Ω.consitent

--- a/Logic/Modal/Normal/Deduction.lean
+++ b/Logic/Modal/Normal/Deduction.lean
@@ -241,7 +241,7 @@ def boxedNecessitation {Γ p} : (Γ ⊢ᴹ[Λ] p) → (□Γ ⊢ᴹ[Λ] □p)
       have d₁ : (□Γ₁ ∪ □Γ₂) ⊢ᴹ[Λ] □(a ⟶ b) := boxedNecessitation h₁ |>.weakening' (by simp);
       have d₂ : (□Γ₁ ∪ □Γ₂) ⊢ᴹ[Λ] □a := boxedNecessitation h₂ |>.weakening' (by simp);
       have : (□Γ₁ ∪ □Γ₂) ⊢ᴹ[Λ] □b := d ⨀ d₁ ⨀ d₂;
-      simpa;
+      simpa [Set.image_union];
 
 instance instBoxedNecessitation : HasBoxedNecessitation (Deduction Λ) := ⟨by apply boxedNecessitation; simpa;⟩
 

--- a/Logic/Modal/Normal/Formula.lean
+++ b/Logic/Modal/Normal/Formula.lean
@@ -28,12 +28,10 @@ instance : StandardModalLogicalConnective (Formula α) where
   vee := or
   top := verum
   bot := falsum
-  mop i := match i with
-    | 0 => box
-    | 1 => dia
-  mop_injective := by
-    simp_all [Function.Injective]
-    aesop;
+  mop b := match b with
+    | true => box
+    | false => dia
+  mop_injective := by simp_all [Function.Injective]
   duality := by simp;
 
 instance : NegDefinition (Formula α) where

--- a/Logic/Modal/Normal/Formula.lean
+++ b/Logic/Modal/Normal/Formula.lean
@@ -21,21 +21,23 @@ variable {α : Type u}
 
 @[simp] def dia (p : Formula α) : Formula α := neg (box (neg p))
 
-instance : ModalLogicSymbol (Formula α) where
+instance : StandardModalLogicalConnective (Formula α) where
   tilde := neg
   arrow := imp
   wedge := and
   vee := or
   top := verum
   bot := falsum
-  box := box
-  dia := dia
+  mop i := match i with
+    | 0 => box
+    | 1 => dia
+  mop_injective := by
+    simp_all [Function.Injective]
+    aesop;
+  duality := by simp;
 
 instance : NegDefinition (Formula α) where
   neg := rfl
-
-instance : ModalDuality (Formula α) where
-  dia_to_box := rfl
 
 section ToString
 
@@ -48,7 +50,7 @@ def toStr : Formula α → String
   | p ⟶ q   => "\\left(" ++ toStr p ++ " \\to "   ++ toStr q ++ "\\right)"
   | p ⋏ q   => "\\left(" ++ toStr p ++ " \\land " ++ toStr q ++ "\\right)"
   | p ⋎ q   => "\\left(" ++ toStr p ++ " \\lor "   ++ toStr q ++ "\\right)"
-  | □p      => "\\Box " ++ toStr p
+  | box p   => "\\Box " ++ toStr p
 
 instance : Repr (Formula α) := ⟨fun t _ => toStr t⟩
 
@@ -77,10 +79,6 @@ lemma dia_eq (p : Formula α) : ◇p = ~(□(~p)) := rfl
 @[simp] lemma imp_inj (p₁ q₁ p₂ q₂ : Formula α) : p₁ ⟶ p₂ = q₁ ⟶ q₂ ↔ p₁ = q₁ ∧ p₂ = q₂ := by simp[Arrow.arrow]
 
 @[simp] lemma neg_inj (p q : Formula α) : ~p = ~q ↔ p = q := by simp [NegDefinition.neg]
-
-instance : ModalInjective (Formula α) where
-  box_injective := by simp [Function.Injective, Box.box]
-  dia_injective := by simp [Function.Injective, Dia.dia]
 
 def complexity : Formula α → ℕ
 | atom _  => 0
@@ -114,7 +112,7 @@ def cases' {C : Formula α → Sort w}
   | p ⟶ q  => himp p q
   | p ⋏ q   => hand p q
   | p ⋎ q   => hor p q
-  | □p      => hbox p
+  | box p      => hbox p
 
 @[elab_as_elim]
 def rec' {C : Formula α → Sort w}
@@ -130,7 +128,7 @@ def rec' {C : Formula α → Sort w}
   | p ⟶ q  => himp p q (rec' hfalsum hatom himp hand hor hbox p) (rec' hfalsum hatom himp hand hor hbox q)
   | p ⋏ q  => hand p q (rec' hfalsum hatom himp hand hor hbox p) (rec' hfalsum hatom himp hand hor hbox q)
   | p ⋎ q  => hor p q (rec' hfalsum hatom himp hand hor hbox p) (rec' hfalsum hatom himp hand hor hbox q)
-  | □p     => hbox p (rec' hfalsum hatom himp hand hor hbox p)
+  | box p     => hbox p (rec' hfalsum hatom himp hand hor hbox p)
 
 -- @[simp] lemma complexity_neg (p : Formula α) : complexity (~p) = p.complexity + 1 :=
 --   by induction p using rec' <;> try { simp[neg_eq, neg, *]; rfl;}
@@ -173,65 +171,24 @@ def hasDecEq : (p q : Formula α) → Decidable (p = q)
         | isTrue hq  => isTrue (hp ▸ hq ▸ rfl)
         | isFalse hq => isFalse (by simp[hp, hq])
       | isFalse hp => isFalse (by simp[hp])
-  | □p, q => by
+  | box p, q => by
     cases q using cases' <;> try { simp; exact isFalse not_false }
     case hbox p' =>
       exact match hasDecEq p p' with
       | isTrue hp  => isTrue (hp ▸ rfl)
-      | isFalse hp => isFalse (by simp[hp])
+      | isFalse hp => isFalse (by simp[hp, box_eq])
 
 instance : DecidableEq (Formula α) := hasDecEq
 
 end Decidable
 
 def isBox : Formula α → Bool
-  | □_ => true
+  | box _ => true
   | _  => false
 
 end Formula
 
 abbrev Theory (α : Type u) := Set (Formula α)
-
-namespace Theory
-
-variable (Γ : Theory α)
-
-@[simp] def box : Theory α := Set.box Γ
-prefix:73 "□" => Theory.box
-
-@[simp] def dia : Theory α := Set.dia Γ
-prefix:73 "◇" => Theory.dia
-
-@[simp] def prebox : Theory α := Set.prebox Γ
-prefix:73 "□⁻¹" => Theory.prebox
-
-@[simp] def predia : Theory α := Set.predia Γ
-prefix:73 "◇⁻¹" => Theory.predia
-
-@[simp] def multibox (n : ℕ) (Γ : Theory α) : Theory α := Set.multibox n Γ
-notation:72 "□[" n:90 "]" Γ:80 => Theory.multibox n Γ
-
-@[simp] def multidia (n : ℕ) (Γ : Theory α) : Theory α := Set.multidia n Γ
-notation:72 "◇[" n:90 "]" Γ:80 => Theory.multidia n Γ
-
-@[simp] def premultibox (n : ℕ) (Γ : Theory α) : Theory α := Set.premultibox n Γ
-notation:72 "□⁻¹[" n:90 "]" Γ:80 => Theory.premultibox n Γ
-
-@[simp] def premultidia (n : ℕ) (Γ : Theory α) : Theory α := Set.premultidia n Γ
-notation:72 "◇⁻¹[" n:90 "]" Γ:80 => Theory.premultidia n Γ
-
-variable {Γ}
-
-@[simp] lemma prebox_box_eq : □⁻¹□Γ = Γ := by simp;
-
-@[simp] lemma predia_dia_eq : ◇⁻¹◇Γ = Γ := by simp;
-
-@[simp] lemma premultibox_multibox_eq : □⁻¹[n](□[n]Γ) = Γ := by simp;
-
-@[simp] lemma premultidia_multidia_eq : ◇⁻¹[n](◇[n]Γ) = Γ := by simp;
-
-end Theory
-
 
 abbrev Context (α : Type u) := Finset (Formula α)
 
@@ -245,48 +202,6 @@ prefix:75 "⋀" => conj
 
 @[simp] noncomputable def disj : Formula α := Finset.disj Γ
 prefix:75 "⋁" => disj
-
-@[simp] noncomputable abbrev box : Context α := Finset.box Γ
-prefix:75 "□" => box
-
-@[simp] noncomputable def dia : Context α := Finset.dia Γ
-prefix:75 "◇" => dia
-
-@[simp] noncomputable def multibox (n : ℕ) (Γ : Context α) : Context α := Finset.multibox n Γ
-notation:75 "□[" n:90 "]" Γ:80 => Context.multibox n Γ
-
-@[simp] noncomputable def multidia (n : ℕ)  (Γ : Context α) : Context α := Finset.multidia n Γ
-notation:75 "◇[" n:90 "]" Γ:80 => Context.multidia n Γ
-
-@[simp] noncomputable def prebox (Γ : Context α) : Context α := Finset.prebox Γ
-prefix:75 "□⁻¹" => Context.prebox
-
-@[simp] noncomputable def predia (Γ : Context α) : Context α := Finset.predia Γ
-prefix:75 "◇⁻¹" => Context.predia
-
-@[simp] noncomputable def premultibox (n : ℕ) (Γ : Context α) : Context α := Finset.premultibox n Γ
-notation:75 "□⁻¹[" n:90 "]" Γ:80 => Context.premultibox n Γ
-
-@[simp] noncomputable def premultidia (n : ℕ) (Γ : Context α) : Context α := Finset.premultidia n Γ
-notation:75 "◇⁻¹[" n:90 "]" Γ:80 => Context.premultidia n Γ
-
-variable {Γ : Context α}
-
-@[simp] lemma box_coe_eq : ↑(□Γ : Context α) = □(↑Γ : Theory α) := by apply Finset.multibox_coe
-
-@[simp] lemma dia_coe_eq  : ↑(◇Γ : Context α) = ◇(↑Γ : Theory α) := by apply Finset.multidia_coe
-
-@[simp] lemma multibox_coe_eq : ↑(□[n]Γ : Context α) = □[n](↑Γ : Theory α) := by apply Finset.multibox_coe
-
-@[simp] lemma multidia_coe_eq : ↑(◇[n]Γ : Context α) = ◇[n](↑Γ : Theory α) := by apply Finset.multidia_coe
-
-@[simp] lemma prebox_coe_eq : ↑(□⁻¹Γ : Context α) = (□⁻¹(↑Γ : Theory α)) := by apply Finset.premultibox_coe
-
-@[simp] lemma predia_coe_eq : ↑(◇⁻¹Γ : Context α) = (◇⁻¹(↑Γ : Theory α)) := by apply Finset.premultidia_coe
-
-@[simp] lemma premultibox_coe_eq : ↑(□⁻¹[n]Γ : Context α) = (□⁻¹[n](↑Γ : Theory α)) := by apply Finset.premultibox_coe
-
-@[simp] lemma premultidia_coe_eq : ↑(◇⁻¹[n]Γ : Context α) = (◇⁻¹[n](↑Γ : Theory α)) := by apply Finset.premultidia_coe
 
 end Context
 

--- a/Logic/Modal/Normal/Formula.lean
+++ b/Logic/Modal/Normal/Formula.lean
@@ -1,4 +1,4 @@
-import Logic.Modal.Normal.LogicSymbol
+import Logic.Modal.LogicSymbol
 
 namespace LO.Modal.Normal
 

--- a/Logic/Modal/Normal/Geach.lean
+++ b/Logic/Modal/Normal/Geach.lean
@@ -11,6 +11,8 @@ import Logic.Modal.Normal.Completeness
 
 namespace LO.Modal.Normal
 
+open Finset
+
 variable {α : Type u} {β : Type u}
 variable [Inhabited β]
 
@@ -253,16 +255,14 @@ lemma def_axiomGeach (hK : 𝐊 ⊆ Λ) (hG : (AxiomSet.Geach l) ⊆ Λ) : (Geac
       have : □[l.m](↑Δ₂ : Theory β) ⊆ Ω₂ := subset_premulitimop_iff_multimop_subset hΔ₂;
       simp only [←Finset.premultimop_coe] at this;
       intro p hp;
-      apply this;
-      sorry;
+      exact this $ multimop_mem_coe.mp hp;
 
     have h₃ : □[l.n](⋀Δ₃) ∈ Ω₃ := by -- TODO: refactor
       apply context_multibox_conj_membership_iff' hK |>.mpr;
       have : □[l.n](↑Δ₃ : Theory β) ⊆ Ω₃ := subset_premulitimop_iff_multimop_subset hΔ₃;
       simp only [←Finset.premultimop_coe] at this;
       intro p hp;
-      apply this;
-      sorry;
+      exact this $ multimop_mem_coe.mp hp;
 
     have : (□[l.n](⋀Δ₃)) ∉ Ω₃ := by
       have : Ω₁ ⊢ᴹ[Λ]! ◇[l.i](□[l.m](⋀Δ₂)) ⟶ □[l.j](◇[l.n](⋀Δ₂)) := Deducible.maxm! (by apply hG; simp [AxiomSet.Geach]);

--- a/Logic/Modal/Normal/Geach.lean
+++ b/Logic/Modal/Normal/Geach.lean
@@ -28,7 +28,7 @@ section Axioms
 
 variable {F : Type u} [StandardModalLogicalConnective F]
 
-abbrev axiomGeach (l : GeachTaple) (p : F) := (◇[l.i](□[l.m]p)) ⟶ (□[l.j](◇[l.n]p))
+abbrev axiomGeach (l : GeachTaple) (p : F) := (◇^[l.i](□^[l.m]p)) ⟶ (□^[l.j](◇^[l.n]p))
 
 abbrev AxiomSet.Geach (l : GeachTaple) : AxiomSet α := { axiomGeach l p | (p) }
 
@@ -197,7 +197,7 @@ theorem AxiomGeach.defines (t : GeachTaple) (F : Frame α) : (GeachConfluency t 
       frame := F,
       val := λ v _ => F[t.m] y v
     }
-    have him : x ⊩ᴹ[M] ◇[t.i](□[t.m](Formula.atom default)) := by aesop;
+    have him : x ⊩ᴹ[M] ◇^[t.i](□^[t.m](Formula.atom default)) := by aesop;
     have := h (Formula.atom default) M.val x |>.modus_ponens him;
     simp only [Formula.Satisfies.multibox_def] at this;
     obtain ⟨u, hzu, hyu⟩ := by simpa using this z hj;
@@ -246,40 +246,40 @@ lemma def_axiomGeach (hK : 𝐊 ⊆ Λ) (hG : (AxiomSet.Geach l) ⊆ Λ) : (Geac
 
   intro Ω₁ Ω₂ Ω₃ h;
   replace ⟨h₁₂, h₂₃⟩ := h;
-  have ⟨Ω, hΩ⟩ := exists_maximal_consistent_theory (show Theory.Consistent Λ ((□⁻¹[l.m]Ω₂.theory) ∪ (□⁻¹[l.n]Ω₃.theory)) by
+  have ⟨Ω, hΩ⟩ := exists_maximal_consistent_theory (show Theory.Consistent Λ ((□⁻¹^[l.m]Ω₂.theory) ∪ (□⁻¹^[l.n]Ω₃.theory)) by
     by_contra hInc;
     obtain ⟨Δ₂, Δ₃, hΔ₂, hΔ₃, hUd⟩ := inconsistent_union (by simpa only [Theory.Inconsistent_iff] using hInc);
 
-    have h₂ : □[l.m](⋀Δ₂) ∈ Ω₂ := by -- TODO: refactor
+    have h₂ : □^[l.m](⋀Δ₂) ∈ Ω₂ := by -- TODO: refactor
       apply context_multibox_conj_membership_iff' hK |>.mpr;
-      have : □[l.m](↑Δ₂ : Theory β) ⊆ Ω₂ := subset_premulitimop_iff_multimop_subset hΔ₂;
+      have : □^[l.m](↑Δ₂ : Theory β) ⊆ Ω₂ := subset_premulitimop_iff_multimop_subset hΔ₂;
       simp only [←Finset.premultimop_coe] at this;
       intro p hp;
       exact this $ multimop_mem_coe.mp hp;
 
-    have h₃ : □[l.n](⋀Δ₃) ∈ Ω₃ := by -- TODO: refactor
+    have h₃ : □^[l.n](⋀Δ₃) ∈ Ω₃ := by -- TODO: refactor
       apply context_multibox_conj_membership_iff' hK |>.mpr;
-      have : □[l.n](↑Δ₃ : Theory β) ⊆ Ω₃ := subset_premulitimop_iff_multimop_subset hΔ₃;
+      have : □^[l.n](↑Δ₃ : Theory β) ⊆ Ω₃ := subset_premulitimop_iff_multimop_subset hΔ₃;
       simp only [←Finset.premultimop_coe] at this;
       intro p hp;
       exact this $ multimop_mem_coe.mp hp;
 
-    have : (□[l.n](⋀Δ₃)) ∉ Ω₃ := by
-      have : Ω₁ ⊢ᴹ[Λ]! ◇[l.i](□[l.m](⋀Δ₂)) ⟶ □[l.j](◇[l.n](⋀Δ₂)) := Deducible.maxm! (by apply hG; simp [AxiomSet.Geach]);
-      have : Ω₁ ⊢ᴹ[Λ]! ◇[l.i](□[l.m](⋀Δ₂)) := membership_iff.mp $ (multiframe_dia hK |>.mp h₁₂) h₂;
-      have : Ω₁ ⊢ᴹ[Λ]! □[l.j](◇[l.n](⋀Δ₂)) := (by assumption) ⨀ (by assumption);
-      have : □[l.j](◇[l.n](⋀Δ₂)) ∈ Ω₁ := membership_iff.mpr this;
-      have : ◇[l.n](⋀Δ₂) ∈ Ω₃ := multiframe_box hK |>.mp h₂₃ (by assumption);
-      have : Ω₃ ⊢ᴹ[Λ]! ◇[l.n](⋀Δ₂) := membership_iff.mp (by assumption);
-      have : Ω₃ ⊢ᴹ[Λ]! ~(□[l.n](~(⋀Δ₂))) := (iff_mp'! multidia_duality!) ⨀ (by assumption);
+    have : (□^[l.n](⋀Δ₃)) ∉ Ω₃ := by
+      have : Ω₁ ⊢ᴹ[Λ]! ◇^[l.i](□^[l.m](⋀Δ₂)) ⟶ □^[l.j](◇^[l.n](⋀Δ₂)) := Deducible.maxm! (by apply hG; simp [AxiomSet.Geach]);
+      have : Ω₁ ⊢ᴹ[Λ]! ◇^[l.i](□^[l.m](⋀Δ₂)) := membership_iff.mp $ (multiframe_dia hK |>.mp h₁₂) h₂;
+      have : Ω₁ ⊢ᴹ[Λ]! □^[l.j](◇^[l.n](⋀Δ₂)) := (by assumption) ⨀ (by assumption);
+      have : □^[l.j](◇^[l.n](⋀Δ₂)) ∈ Ω₁ := membership_iff.mpr this;
+      have : ◇^[l.n](⋀Δ₂) ∈ Ω₃ := multiframe_box hK |>.mp h₂₃ (by assumption);
+      have : Ω₃ ⊢ᴹ[Λ]! ◇^[l.n](⋀Δ₂) := membership_iff.mp (by assumption);
+      have : Ω₃ ⊢ᴹ[Λ]! ~(□^[l.n](~(⋀Δ₂))) := (iff_mp'! multidia_duality!) ⨀ (by assumption);
       have : ∅ ⊢ᴹ[Λ]! ~⋀(Δ₂ ∪ Δ₃) := by simpa [NegDefinition.neg] using finset_dt!.mp (by simpa using hUd);
       have : ∅ ⊢ᴹ[Λ]! ~⋀(Δ₂ ∪ Δ₃) ⟶ ~(⋀Δ₂ ⋏ ⋀Δ₃) := contra₀'! $ iff_mpr'! $ finset_union_conj!;
       have : ∅ ⊢ᴹ[Λ]! (⋀Δ₂ ⋏ ⋀Δ₃) ⟶ ⊥ := (by assumption) ⨀ (by assumption);
       have : ∅ ⊢ᴹ[Λ]! ~(⋀Δ₂ ⋏ ⋀Δ₃) := (contra₀'! (by assumption)) ⨀ (by deduct);
       have : ∅ ⊢ᴹ[Λ]! ⋀Δ₃ ⟶ ~⋀Δ₂ := imp_eq!.mpr $ disj_symm'! $ neg_conj'! (by assumption);
-      have : ∅ ⊢ᴹ[Λ]! □[l.n](⋀Δ₃) ⟶ □[l.n](~⋀Δ₂) := multibox_distribute_nec'! (by assumption);
-      have : Ω₃ ⊢ᴹ[Λ]! ~(□[l.n](~⋀Δ₂)) ⟶ ~(□[l.n](⋀Δ₃)) := weakening! (show ∅ ⊆ Ω₃.theory by simp) $ contra₀'! (by assumption);
-      have : Ω₃ ⊢ᴹ[Λ]! ~(□[l.n](⋀Δ₃)) := (by assumption) ⨀ (by assumption);
+      have : ∅ ⊢ᴹ[Λ]! □^[l.n](⋀Δ₃) ⟶ □^[l.n](~⋀Δ₂) := multibox_distribute_nec'! (by assumption);
+      have : Ω₃ ⊢ᴹ[Λ]! ~(□^[l.n](~⋀Δ₂)) ⟶ ~(□^[l.n](⋀Δ₃)) := weakening! (show ∅ ⊆ Ω₃.theory by simp) $ contra₀'! (by assumption);
+      have : Ω₃ ⊢ᴹ[Λ]! ~(□^[l.n](⋀Δ₃)) := (by assumption) ⨀ (by assumption);
       exact neg_membership_iff.mp $ membership_iff.mpr (by assumption);
 
     contradiction;
@@ -289,11 +289,11 @@ lemma def_axiomGeach (hK : 𝐊 ⊆ Λ) (hG : (AxiomSet.Geach l) ⊆ Λ) : (Geac
   constructor;
   . intro p hp;
     apply hΩ;
-    have : p ∈ □⁻¹[l.m]Ω₂ := by simpa [Set.premultibox] using hp;
+    have : p ∈ □⁻¹^[l.m]Ω₂ := by simpa [Set.premultibox] using hp;
     simp_all;
   . intro p hp;
     apply hΩ;
-    have : p ∈ □⁻¹[l.n]Ω₃ := by simpa [Set.premultibox] using hp;
+    have : p ∈ □⁻¹^[l.n]Ω₃ := by simpa [Set.premultibox] using hp;
     simp_all;
 
 lemma def_logicGeach {l : GeachTapleList} (hG : (GeachLogic l) ⊆ Λ) : (GeachConfluencyList l) (CanonicalModel Λ).frame := by

--- a/Logic/Modal/Normal/Geach.lean
+++ b/Logic/Modal/Normal/Geach.lean
@@ -24,7 +24,7 @@ abbrev GeachTapleList := List GeachTaple
 
 section Axioms
 
-variable {F : Type u} [ModalLogicSymbol F]
+variable {F : Type u} [StandardModalLogicalConnective F]
 
 abbrev axiomGeach (l : GeachTaple) (p : F) := (◇[l.i](□[l.m]p)) ⟶ (□[l.j](◇[l.n]p))
 
@@ -250,17 +250,19 @@ lemma def_axiomGeach (hK : 𝐊 ⊆ Λ) (hG : (AxiomSet.Geach l) ⊆ Λ) : (Geac
 
     have h₂ : □[l.m](⋀Δ₂) ∈ Ω₂ := by -- TODO: refactor
       apply context_multibox_conj_membership_iff' hK |>.mpr;
-      have : □[l.m](↑Δ₂ : Theory β) ⊆ Ω₂ := subset_premulitibox_iff_multibox_subset hΔ₂;
-      simp only [←Context.multibox_coe_eq] at this;
+      have : □[l.m](↑Δ₂ : Theory β) ⊆ Ω₂ := subset_premulitimop_iff_multimop_subset hΔ₂;
+      simp only [←Finset.premultimop_coe] at this;
       intro p hp;
-      exact this hp;
+      apply this;
+      sorry;
 
     have h₃ : □[l.n](⋀Δ₃) ∈ Ω₃ := by -- TODO: refactor
       apply context_multibox_conj_membership_iff' hK |>.mpr;
-      have : □[l.n](↑Δ₃ : Theory β) ⊆ Ω₃ := subset_premulitibox_iff_multibox_subset hΔ₃;
-      simp only [←Context.multibox_coe_eq] at this;
+      have : □[l.n](↑Δ₃ : Theory β) ⊆ Ω₃ := subset_premulitimop_iff_multimop_subset hΔ₃;
+      simp only [←Finset.premultimop_coe] at this;
       intro p hp;
-      exact this hp;
+      apply this;
+      sorry;
 
     have : (□[l.n](⋀Δ₃)) ∉ Ω₃ := by
       have : Ω₁ ⊢ᴹ[Λ]! ◇[l.i](□[l.m](⋀Δ₂)) ⟶ □[l.j](◇[l.n](⋀Δ₂)) := Deducible.maxm! (by apply hG; simp [AxiomSet.Geach]);

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -159,7 +159,7 @@ lemma box_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! (□p ⟷ □q) := ⟨box_iff' 
 
 @[inference]
 def dia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ (◇p ⟷ ◇q) := by
-  simp only [duality];
+  simp only [duality'];
   apply neg_iff';
   apply box_iff';
   apply neg_iff';
@@ -193,7 +193,7 @@ lemma multidia_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! ◇[n]p ⟷ ◇[n]q := ⟨
 
 @[tautology]
 def box_duality : Γ ⊢ □p ⟷ ~(◇~p) := by
-  simp [duality];
+  simp [duality'];
   have d₁ : Γ ⊢ □p ⟷ (□~~p) := by deduct;
   have d₂ : Γ ⊢ (□~~p) ⟷ ~~(□~~p) := by deduct;
   simpa [duality] using iff_trans' d₁ d₂
@@ -203,7 +203,7 @@ lemma box_duality! : Γ ⊢! □p ⟷ ~(◇~p) := ⟨box_duality⟩
 
 @[tautology]
 def dia_duality : Γ ⊢ ◇p ⟷ ~(□~p) := by
-  simp only [duality];
+  simp only [duality'];
   apply neg_iff';
   apply iff_id;
 
@@ -217,11 +217,11 @@ def multibox_duality : Γ ⊢ □[n]p ⟷ ~(◇[n](~p)) := by
   induction n generalizing Γ with
   | zero => deduct
   | succ n ih =>
-    simp [duality];
+    simp [duality'];
     exact iff_trans'
       (show Γ ⊢ □□[n]p ⟷ ~~(□~~(□[n]p)) by
         have : Γ ⊢ □(□[n]p) ⟷ ~(◇~(□[n]p)) := box_duality
-        simpa [duality];
+        simpa [duality'];
       )
       (by
         have : ∅ ⊢ ~~(□[n]p) ⟷ □[n]p := by deduct;
@@ -239,7 +239,7 @@ def multidia_duality : Γ ⊢ ◇[n]p ⟷ ~(□[n](~p)) := by
   induction n generalizing Γ with
   | zero => apply dn;
   | succ n ih =>
-    simp [duality];
+    simp [duality'];
     apply neg_iff';
     apply box_iff';
     exact iff_trans' (neg_iff' $ ih) (by deduct);
@@ -411,7 +411,7 @@ lemma distribute_multidia_list_conj'! {Γ : Set F} {Δ : List F} (d : Γ ⊢! �
 lemma distribute_multidia_finset_conj'! {Γ : Set F} {Δ : Finset F} (d : Γ ⊢! ◇[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
   apply finset_conj_iff!.mpr;
   intro p hp;
-  exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simpa [Finset.multidia] using hp);
+  exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simp [Finset.multidia] at hp; sorry;);
 
 lemma distribute_dia_finset_conj'! {Δ : Finset F} (d : Γ ⊢! ◇(Δ.conj)) : Γ ⊢! Δ.dia.conj := by
   have : (Γ ⊢! ◇[1]Δ.conj) → (Γ ⊢! (Δ.multidia 1).conj) := distribute_multidia_finset_conj'!;
@@ -424,7 +424,7 @@ lemma distribute_multidia_finset_conj! {n : ℕ} {Γ : Set F} {Δ : Finset F} : 
 
 @[tautology]
 def collect_dia_disj : Γ ⊢ ◇p ⋎ ◇q ⟶ ◇(p ⋎ q) := by
-  simp [duality];
+  simp [duality'];
   apply contra₁';
   apply dtr';
   apply conj_neg';

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -1,5 +1,4 @@
 import Logic.Logic.Deduction
-import Logic.Modal.Normal.LogicSymbol
 import Logic.Modal.Normal.Axioms
 
 namespace LO.Hilbert

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -393,7 +393,7 @@ def distribute_multidia_conj : Γ ⊢ ◇[n](p ⋏ q) ⟶ (◇[n]p ⋏ ◇[n]q) 
     have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ ◇(◇[n]p ⋏ ◇[n]q) := by simpa [duality] using this;
     have : ∅ ⊢ ◇(◇[n]p ⋏ ◇[n]q) ⟶ (◇◇[n]p ⋏ ◇◇[n]q) := distribute_dia_conj
     have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ (◇[(n + 1)]p ⋏ ◇[(n + 1)]q) := imp_trans' (by assumption) (by simpa using this);
-    sorry; -- simpa using this;
+    simpa using weakening' (by simp) this;
 
 @[inference]
 def distribute_multidia_conj' (d : Γ ⊢ ◇[n](p ⋏ q)) : Γ ⊢ ◇[n]p ⋏ ◇[n]q := distribute_multidia_conj ⨀ d

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -118,7 +118,7 @@ def multiaxiomK : Γ ⊢ □[n](p ⟶ q) ⟶ (□[n]p ⟶ □[n]q) := by
   | succ n ih =>
     have d₁ : Γ ⊢ □□[n](p ⟶ q) ⟶ □(□[n]p ⟶ □[n]q) := box_distribute_nec' ih;
     have d₂ : Γ ⊢ □(□[n]p ⟶ □[n]q) ⟶ □□[n]p ⟶ □□[n]q := by deduct;
-    exact imp_trans' d₁ d₂;
+    simpa using imp_trans' d₁ d₂;
 
 @[inference]
 def multibox_distribute' (d : Γ ⊢ □[n](p ⟶ q)) :  Γ ⊢ □[n]p ⟶ □[n]q := multiaxiomK ⨀ d
@@ -170,7 +170,10 @@ lemma dia_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! (◇p ⟷ ◇q) := ⟨dia_iff' 
 def multibox_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ □[n]p ⟷ □[n]q := by
   induction n generalizing Γ with
   | zero => deduct;
-  | succ => apply iff_intro'; all_goals { apply box_distribute_nec'; deduct; }
+  | succ =>
+    simp;
+    apply iff_intro';
+    all_goals { apply box_distribute_nec'; deduct; }
 
 @[inference]
 lemma multibox_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! □[n]p ⟷ □[n]q := ⟨multibox_iff' d.some⟩
@@ -389,8 +392,8 @@ def distribute_multidia_conj : Γ ⊢ ◇[n](p ⋏ q) ⟶ (◇[n]p ⋏ ◇[n]q) 
     have : ∅ ⊢ ~(□~(◇[n](p ⋏ q))) ⟶ ~(□~(◇[n]p ⋏ ◇[n]q)) := contra₀' this;
     have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ ◇(◇[n]p ⋏ ◇[n]q) := by simpa [duality] using this;
     have : ∅ ⊢ ◇(◇[n]p ⋏ ◇[n]q) ⟶ (◇◇[n]p ⋏ ◇◇[n]q) := distribute_dia_conj
-    have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ (◇[(n + 1)]p ⋏ ◇[(n + 1)]q) := imp_trans' (by assumption) this;
-    deduct;
+    have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ (◇[(n + 1)]p ⋏ ◇[(n + 1)]q) := imp_trans' (by assumption) (by simpa using this);
+    sorry; -- simpa using this;
 
 @[inference]
 def distribute_multidia_conj' (d : Γ ⊢ ◇[n](p ⋏ q)) : Γ ⊢ ◇[n]p ⋏ ◇[n]q := distribute_multidia_conj ⨀ d

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -76,10 +76,10 @@ def necessitation (d : ∅ ⊢ p) : Γ ⊢ □p := HasNecessitation.necessitatio
 def necessitation! (d : ∅ ⊢! p) : Γ ⊢! □p := ⟨necessitation d.some⟩
 
 @[inference]
-def multi_necessitation (d : (∅ : Set F) ⊢ p) : Γ ⊢ □[n]p := by induction n generalizing Γ <;> deduct
+def multi_necessitation (d : (∅ : Set F) ⊢ p) : Γ ⊢ □^[n]p := by induction n generalizing Γ <;> deduct
 
 @[inference]
-def multi_necessitation! (d : ∅ ⊢! p) : Γ ⊢! □[n]p := ⟨multi_necessitation d.some⟩
+def multi_necessitation! (d : ∅ ⊢! p) : Γ ⊢! □^[n]p := ⟨multi_necessitation d.some⟩
 
 @[inference]
 def boxed_necessitation (d : Γ ⊢ p) : Γ.box ⊢ □p := HasBoxedNecessitation.boxed_necessitation d
@@ -112,25 +112,25 @@ def box_distribute_nec' (d₁ : ∅ ⊢ p ⟶ q) : Γ ⊢ □p ⟶ □q := box_d
 lemma box_distribute_nec'! (d : ∅ ⊢! p ⟶ q) : Γ ⊢! □p ⟶ □q := ⟨box_distribute_nec' d.some⟩
 
 @[tautology]
-def multiaxiomK : Γ ⊢ □[n](p ⟶ q) ⟶ (□[n]p ⟶ □[n]q) := by
+def multiaxiomK : Γ ⊢ □^[n](p ⟶ q) ⟶ (□^[n]p ⟶ □^[n]q) := by
   induction n generalizing Γ with
   | zero => deduct
   | succ n ih =>
-    have d₁ : Γ ⊢ □□[n](p ⟶ q) ⟶ □(□[n]p ⟶ □[n]q) := box_distribute_nec' ih;
-    have d₂ : Γ ⊢ □(□[n]p ⟶ □[n]q) ⟶ □□[n]p ⟶ □□[n]q := by deduct;
+    have d₁ : Γ ⊢ □□^[n](p ⟶ q) ⟶ □(□^[n]p ⟶ □^[n]q) := box_distribute_nec' ih;
+    have d₂ : Γ ⊢ □(□^[n]p ⟶ □^[n]q) ⟶ □□^[n]p ⟶ □□^[n]q := by deduct;
     simpa using imp_trans' d₁ d₂;
 
 @[inference]
-def multibox_distribute' (d : Γ ⊢ □[n](p ⟶ q)) :  Γ ⊢ □[n]p ⟶ □[n]q := multiaxiomK ⨀ d
+def multibox_distribute' (d : Γ ⊢ □^[n](p ⟶ q)) :  Γ ⊢ □^[n]p ⟶ □^[n]q := multiaxiomK ⨀ d
 
 @[inference]
-lemma multibox_distribute'! (d : Γ ⊢! □[n](p ⟶ q)) : Γ ⊢! □[n]p ⟶ □[n]q := ⟨multibox_distribute' d.some⟩
+lemma multibox_distribute'! (d : Γ ⊢! □^[n](p ⟶ q)) : Γ ⊢! □^[n]p ⟶ □^[n]q := ⟨multibox_distribute' d.some⟩
 
 @[tautology]
-def multibox_distribute_nec' (d : ∅ ⊢ p ⟶ q) : Γ ⊢ □[n]p ⟶ □[n]q := multibox_distribute' $ multi_necessitation d
+def multibox_distribute_nec' (d : ∅ ⊢ p ⟶ q) : Γ ⊢ □^[n]p ⟶ □^[n]q := multibox_distribute' $ multi_necessitation d
 
 @[inference]
-lemma multibox_distribute_nec'! (d : ∅ ⊢! p ⟶ q) : Γ ⊢! □[n]p ⟶ □[n]q := ⟨multibox_distribute_nec' d.some⟩
+lemma multibox_distribute_nec'! (d : ∅ ⊢! p ⟶ q) : Γ ⊢! □^[n]p ⟶ □^[n]q := ⟨multibox_distribute_nec' d.some⟩
 
 @[inference]
 def axiomK' (d₁ : Γ ⊢ (□(p ⟶ q))) (d₂ : Γ ⊢ □p) : Γ ⊢ □q := axiomK ⨀ d₁ ⨀ d₂
@@ -167,7 +167,7 @@ def dia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ (◇p ⟷ ◇q) := by
 lemma dia_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! (◇p ⟷ ◇q) := ⟨dia_iff' d.some⟩
 
 @[inference]
-def multibox_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ □[n]p ⟷ □[n]q := by
+def multibox_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ □^[n]p ⟷ □^[n]q := by
   induction n generalizing Γ with
   | zero => deduct;
   | succ =>
@@ -176,10 +176,10 @@ def multibox_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ □[n]p ⟷ □[n]q := by
     all_goals { apply box_distribute_nec'; deduct; }
 
 @[inference]
-lemma multibox_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! □[n]p ⟷ □[n]q := ⟨multibox_iff' d.some⟩
+lemma multibox_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! □^[n]p ⟷ □^[n]q := ⟨multibox_iff' d.some⟩
 
 @[inference]
-def multidia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ ◇[n]p ⟷ ◇[n]q := by
+def multidia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ ◇^[n]p ⟷ ◇^[n]q := by
   induction n generalizing Γ with
   | zero => deduct;
   | succ n ih =>
@@ -190,7 +190,7 @@ def multidia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ ◇[n]p ⟷ ◇[n]q := by
     apply ih;
 
 @[inference]
-lemma multidia_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! ◇[n]p ⟷ ◇[n]q := ⟨multidia_iff' d.some⟩
+lemma multidia_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! ◇^[n]p ⟷ ◇^[n]q := ⟨multidia_iff' d.some⟩
 
 @[tautology]
 def box_duality : Γ ⊢ □p ⟷ ~(◇~p) := by
@@ -214,29 +214,29 @@ lemma dia_duality! : Γ ⊢! ◇p ⟷ ~(□~p) := ⟨dia_duality⟩
 lemma dia_duality_mp' (h : Γ ⊢ ◇p) : Γ ⊢ ~(□~p) := by deduct;
 
 @[tautology]
-def multibox_duality : Γ ⊢ □[n]p ⟷ ~(◇[n](~p)) := by
+def multibox_duality : Γ ⊢ □^[n]p ⟷ ~(◇^[n](~p)) := by
   induction n generalizing Γ with
   | zero => deduct
   | succ n ih =>
     simp [duality'];
     exact iff_trans'
-      (show Γ ⊢ □□[n]p ⟷ ~~(□~~(□[n]p)) by
-        have : Γ ⊢ □(□[n]p) ⟷ ~(◇~(□[n]p)) := box_duality
+      (show Γ ⊢ □□^[n]p ⟷ ~~(□~~(□^[n]p)) by
+        have : Γ ⊢ □(□^[n]p) ⟷ ~(◇~(□^[n]p)) := box_duality
         simpa [duality'];
       )
       (by
-        have : ∅ ⊢ ~~(□[n]p) ⟷ □[n]p := by deduct;
-        have : ∅ ⊢ (□[n]p ⟷ ~(◇[n](~p))) := by deduct;
-        have : ∅ ⊢ ~~(□[n]p) ⟷ ~(◇[n](~p)) := iff_trans' (by assumption) (by assumption);
-        have : ∅ ⊢ □~~(□[n]p) ⟷ □~(◇[n](~p)) := box_iff' (by assumption);
+        have : ∅ ⊢ ~~(□^[n]p) ⟷ □^[n]p := by deduct;
+        have : ∅ ⊢ (□^[n]p ⟷ ~(◇^[n](~p))) := by deduct;
+        have : ∅ ⊢ ~~(□^[n]p) ⟷ ~(◇^[n](~p)) := iff_trans' (by assumption) (by assumption);
+        have : ∅ ⊢ □~~(□^[n]p) ⟷ □~(◇^[n](~p)) := box_iff' (by assumption);
         exact weakening' (by simp) $ dn_iff' this;
       )
 
 @[tautology]
-lemma multibox_duality! {n Γ p} : Γ ⊢! □[n]p ⟷ ~(◇[n](~p)) := ⟨multibox_duality⟩
+lemma multibox_duality! {n Γ p} : Γ ⊢! □^[n]p ⟷ ~(◇^[n](~p)) := ⟨multibox_duality⟩
 
 @[tautology]
-def multidia_duality : Γ ⊢ ◇[n]p ⟷ ~(□[n](~p)) := by
+def multidia_duality : Γ ⊢ ◇^[n]p ⟷ ~(□^[n](~p)) := by
   induction n generalizing Γ with
   | zero => apply dn;
   | succ n ih =>
@@ -246,15 +246,15 @@ def multidia_duality : Γ ⊢ ◇[n]p ⟷ ~(□[n](~p)) := by
     exact iff_trans' (neg_iff' $ ih) (by deduct);
 
 @[tautology]
-lemma multidia_duality! : Γ ⊢! ◇[n]p ⟷ ~(□[n](~p)) := ⟨multidia_duality⟩
+lemma multidia_duality! : Γ ⊢! ◇^[n]p ⟷ ~(□^[n](~p)) := ⟨multidia_duality⟩
 
 @[tautology] def boxverum : Γ ⊢ □⊤ := by deduct;
 
 @[tautology] lemma boxverum! : Γ ⊢! □⊤ := ⟨boxverum⟩
 
-@[tautology] def multiboxverum : Γ ⊢ □[n]⊤ := by deduct;
+@[tautology] def multiboxverum : Γ ⊢ □^[n]⊤ := by deduct;
 
-@[tautology] lemma multiboxverum! : Γ ⊢! □[n]⊤ := ⟨multiboxverum⟩
+@[tautology] lemma multiboxverum! : Γ ⊢! □^[n]⊤ := ⟨multiboxverum⟩
 
 @[tautology]
 def equiv_dianeg_negbox : Γ ⊢ ◇~p ⟷ ~(□p) := by
@@ -269,7 +269,7 @@ lemma equiv_dianeg_negbox! : Γ ⊢! ◇~p ⟷ ~(□p) := ⟨equiv_dianeg_negbox
 
 @[inference] def box_imp' (d : ∅ ⊢ p ⟶ q) : Γ ⊢ □p ⟶ □q := by deduct
 
-@[inference] def multibox_imp' (d : ∅ ⊢ p ⟶ q) : Γ ⊢ □[n]p ⟶ □[n]q := by deduct
+@[inference] def multibox_imp' (d : ∅ ⊢ p ⟶ q) : Γ ⊢ □^[n]p ⟶ □^[n]q := by deduct
 
 @[inference]
 def distribute_box_conj' (d : Γ ⊢ □(p ⋏ q)) : Γ ⊢ □p ⋏ □q := by
@@ -288,14 +288,14 @@ def distribute_box_conj : Γ ⊢ □(p ⋏ q) ⟶ □p ⋏ □q := by apply dtr'
 @[tautology]
 lemma distribute_box_conj! : Γ ⊢! □(p ⋏ q) ⟶ □p ⋏ □q := ⟨distribute_box_conj⟩
 
-def distribute_multibox_conj' (d : Γ ⊢ □[n](p ⋏ q)) : Γ ⊢ □[n]p ⋏ □[n]q := by
-  have dp : ∅ ⊢ □[n](p ⋏ q) ⟶ □[n]p := multibox_imp' (conj₁);
-  have dq : ∅ ⊢ □[n](p ⋏ q) ⟶ □[n]q := multibox_imp' (conj₂);
-  have : Γ ⊢ □[n]p := by simpa using dp ⨀ d;
-  have : Γ ⊢ □[n]q := by simpa using dq ⨀ d;
+def distribute_multibox_conj' (d : Γ ⊢ □^[n](p ⋏ q)) : Γ ⊢ □^[n]p ⋏ □^[n]q := by
+  have dp : ∅ ⊢ □^[n](p ⋏ q) ⟶ □^[n]p := multibox_imp' (conj₁);
+  have dq : ∅ ⊢ □^[n](p ⋏ q) ⟶ □^[n]q := multibox_imp' (conj₂);
+  have : Γ ⊢ □^[n]p := by simpa using dp ⨀ d;
+  have : Γ ⊢ □^[n]q := by simpa using dq ⨀ d;
   exact conj₃' (by assumption) (by assumption);
 
-lemma distribute_multibox_conj'! (d : Γ ⊢! □[n](p ⋏ q)) : Γ ⊢! □[n]p ⋏ □[n]q := ⟨distribute_multibox_conj' d.some⟩
+lemma distribute_multibox_conj'! (d : Γ ⊢! □^[n](p ⋏ q)) : Γ ⊢! □^[n]p ⋏ □^[n]q := ⟨distribute_multibox_conj' d.some⟩
 
 @[inference]
 def collect_box_conj' (d : Γ ⊢ □p ⋏ □q) : Γ ⊢ □(p ⋏ q) := by
@@ -306,12 +306,12 @@ def collect_box_conj' (d : Γ ⊢ □p ⋏ □q) : Γ ⊢ □(p ⋏ q) := by
 @[inference]
 lemma collect_box_conj'! (d : Γ ⊢! □p ⋏ □q) : Γ ⊢! □(p ⋏ q) := ⟨collect_box_conj' d.some⟩
 
-def collect_multibox_conj' (d : Γ ⊢ □[n]p ⋏ □[n]q) : Γ ⊢ □[n](p ⋏ q) := by
-  have : ∅ ⊢ □[n]p ⟶ □[n](q ⟶ (p ⋏ q)) := by deduct
-  have : ∅ ⊢ □[n]p ⟶ □[n]q ⟶ □[n](p ⋏ q) := imp_trans' (by assumption) (by deduct);
+def collect_multibox_conj' (d : Γ ⊢ □^[n]p ⋏ □^[n]q) : Γ ⊢ □^[n](p ⋏ q) := by
+  have : ∅ ⊢ □^[n]p ⟶ □^[n](q ⟶ (p ⋏ q)) := by deduct
+  have : ∅ ⊢ □^[n]p ⟶ □^[n]q ⟶ □^[n](p ⋏ q) := imp_trans' (by assumption) (by deduct);
   simpa using this ⨀ (conj₁' d) ⨀ (conj₂' d)
 
-lemma collect_multibox_conj'! (d : Γ ⊢! □[n]p ⋏ □[n]q) : Γ ⊢! □[n](p ⋏ q) := ⟨collect_multibox_conj' d.some⟩
+lemma collect_multibox_conj'! (d : Γ ⊢! □^[n]p ⋏ □^[n]q) : Γ ⊢! □^[n](p ⋏ q) := ⟨collect_multibox_conj' d.some⟩
 
 @[tautology]
 def collect_box_conj : Γ ⊢ □p ⋏ □q ⟶ □(p ⋏ q) := by apply dtr'; deduct;
@@ -341,7 +341,7 @@ lemma box_list_conj_iff! {Γ : Set F} {Δ : List F} : Γ ⊢! □(Δ.conj) ↔ �
 lemma box_finset_conj_iff! {Γ : Set F} {Δ : Finset F} : Γ ⊢! □(Δ.conj) ↔ ∀ p ∈ Δ, Γ ⊢! □p := by
   simp [Finset.conj, box_list_conj_iff!];
 
-lemma multibox_list_conj_iff! {Γ : Set F} {Δ : List F} : Γ ⊢! □[n](Δ.conj) ↔ ∀ p ∈ Δ, Γ ⊢! □[n]p := by
+lemma multibox_list_conj_iff! {Γ : Set F} {Δ : List F} : Γ ⊢! □^[n](Δ.conj) ↔ ∀ p ∈ Δ, Γ ⊢! □^[n]p := by
   induction Δ with
   | nil => simp [multiboxverum!];
   | cons p Δ ih =>
@@ -355,8 +355,8 @@ lemma multibox_list_conj_iff! {Γ : Set F} {Δ : List F} : Γ ⊢! □[n](Δ.con
     . rintro ⟨h₁, h₂⟩;
       exact collect_multibox_conj'! $ conj₃'! h₁ (ih.mpr h₂);
 
-lemma multibox_finset_conj_iff! {Γ : Set F} {Δ : Finset F} : Γ ⊢! □[n](Δ.conj) ↔ ∀ p ∈ Δ, Γ ⊢! □[n]p := by
-  have : (Γ ⊢! □[n]Δ.toList.conj) ↔ ∀ p ∈ Δ.toList, Γ ⊢! □[n]p := multibox_list_conj_iff!;
+lemma multibox_finset_conj_iff! {Γ : Set F} {Δ : Finset F} : Γ ⊢! □^[n](Δ.conj) ↔ ∀ p ∈ Δ, Γ ⊢! □^[n]p := by
+  have : (Γ ⊢! □^[n]Δ.toList.conj) ↔ ∀ p ∈ Δ.toList, Γ ⊢! □^[n]p := multibox_list_conj_iff!;
   simpa [Finset.toList_toFinset];
 
 @[inference]
@@ -383,25 +383,25 @@ def distribute_dia_conj : Γ ⊢ ◇(p ⋏ q) ⟶ (◇p ⋏ ◇q) := by
 def distribute_dia_conj' (d : Γ ⊢ ◇(p ⋏ q)) : Γ ⊢ ◇p ⋏ ◇q := distribute_dia_conj ⨀ d
 
 @[tautology]
-def distribute_multidia_conj : Γ ⊢ ◇[n](p ⋏ q) ⟶ (◇[n]p ⋏ ◇[n]q) := by
+def distribute_multidia_conj : Γ ⊢ ◇^[n](p ⋏ q) ⟶ (◇^[n]p ⋏ ◇^[n]q) := by
   induction n generalizing Γ with
   | zero => deduct
   | succ n ih =>
-    have : ∅ ⊢ ~(◇[n]p ⋏ ◇[n]q) ⟶ ~(◇[n](p ⋏ q)) := contra₀' ih;
-    have : ∅ ⊢ □~(◇[n]p ⋏ ◇[n]q) ⟶ □~(◇[n](p ⋏ q)) := box_imp' this;
-    have : ∅ ⊢ ~(□~(◇[n](p ⋏ q))) ⟶ ~(□~(◇[n]p ⋏ ◇[n]q)) := contra₀' this;
-    have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ ◇(◇[n]p ⋏ ◇[n]q) := by simpa [duality] using this;
-    have : ∅ ⊢ ◇(◇[n]p ⋏ ◇[n]q) ⟶ (◇◇[n]p ⋏ ◇◇[n]q) := distribute_dia_conj
-    have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ (◇[(n + 1)]p ⋏ ◇[(n + 1)]q) := imp_trans' (by assumption) (by simpa using this);
+    have : ∅ ⊢ ~(◇^[n]p ⋏ ◇^[n]q) ⟶ ~(◇^[n](p ⋏ q)) := contra₀' ih;
+    have : ∅ ⊢ □~(◇^[n]p ⋏ ◇^[n]q) ⟶ □~(◇^[n](p ⋏ q)) := box_imp' this;
+    have : ∅ ⊢ ~(□~(◇^[n](p ⋏ q))) ⟶ ~(□~(◇^[n]p ⋏ ◇^[n]q)) := contra₀' this;
+    have : ∅ ⊢ ◇(◇^[n](p ⋏ q)) ⟶ ◇(◇^[n]p ⋏ ◇^[n]q) := by simpa [duality] using this;
+    have : ∅ ⊢ ◇(◇^[n]p ⋏ ◇^[n]q) ⟶ (◇◇^[n]p ⋏ ◇◇^[n]q) := distribute_dia_conj
+    have : ∅ ⊢ ◇(◇^[n](p ⋏ q)) ⟶ (◇^[(n + 1)]p ⋏ ◇^[(n + 1)]q) := imp_trans' (by assumption) (by simpa using this);
     simpa using weakening' (by simp) this;
 
 @[inference]
-def distribute_multidia_conj' (d : Γ ⊢ ◇[n](p ⋏ q)) : Γ ⊢ ◇[n]p ⋏ ◇[n]q := distribute_multidia_conj ⨀ d
+def distribute_multidia_conj' (d : Γ ⊢ ◇^[n](p ⋏ q)) : Γ ⊢ ◇^[n]p ⋏ ◇^[n]q := distribute_multidia_conj ⨀ d
 
 @[inference]
-lemma distribute_multidia_conj'! (d : Γ ⊢! ◇[n](p ⋏ q)) : Γ ⊢! ◇[n]p ⋏ ◇[n]q := ⟨distribute_multidia_conj' d.some⟩
+lemma distribute_multidia_conj'! (d : Γ ⊢! ◇^[n](p ⋏ q)) : Γ ⊢! ◇^[n]p ⋏ ◇^[n]q := ⟨distribute_multidia_conj' d.some⟩
 
-lemma distribute_multidia_list_conj'! {Γ : Set F} {Δ : List F} (d : Γ ⊢! ◇[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
+lemma distribute_multidia_list_conj'! {Γ : Set F} {Δ : List F} (d : Γ ⊢! ◇^[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
   induction Δ with
   | nil => simp_all [verum!];
   | cons p Δ ih =>
@@ -409,16 +409,16 @@ lemma distribute_multidia_list_conj'! {Γ : Set F} {Δ : List F} (d : Γ ⊢! �
     have d := distribute_multidia_conj'! d;
     exact conj₃'! (conj₁'! d) (by apply ih; apply conj₂'! d);
 
-lemma distribute_multidia_finset_conj'! {Γ : Set F} {Δ : Finset F} (d : Γ ⊢! ◇[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
+lemma distribute_multidia_finset_conj'! {Γ : Set F} {Δ : Finset F} (d : Γ ⊢! ◇^[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
   apply finset_conj_iff!.mpr;
   intro p hp;
   exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simpa [Finset.multidia, List.multidia] using hp);
 
 lemma distribute_dia_finset_conj'! {Δ : Finset F} (d : Γ ⊢! ◇(Δ.conj)) : Γ ⊢! Δ.dia.conj := by
-  have : (Γ ⊢! ◇[1]Δ.conj) → (Γ ⊢! (Δ.multidia 1).conj) := distribute_multidia_finset_conj'!;
+  have : (Γ ⊢! ◇^[1]Δ.conj) → (Γ ⊢! (Δ.multidia 1).conj) := distribute_multidia_finset_conj'!;
   simp_all [Finset.multidia, Finset.dia];
 
-lemma distribute_multidia_finset_conj! {n : ℕ} {Γ : Set F} {Δ : Finset F} : Γ ⊢! ◇[n]Δ.conj ⟶ (Δ.multidia n).conj := by
+lemma distribute_multidia_finset_conj! {n : ℕ} {Γ : Set F} {Δ : Finset F} : Γ ⊢! ◇^[n]Δ.conj ⟶ (Δ.multidia n).conj := by
   apply dtr'!;
   apply distribute_multidia_finset_conj'!;
   apply axm! (by simp);

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -88,7 +88,7 @@ def boxed_necessitation (d : Γ ⊢ p) : Γ.box ⊢ □p := HasBoxedNecessitatio
 def boxed_necessitation! (d : Γ ⊢! p) : Γ.box ⊢! □p := ⟨boxed_necessitation d.some⟩
 
 @[inference]
-def preboxed_necessitation (d : □⁻¹Γ ⊢ p) : Γ ⊢ □p := weakening' (by simp) $ boxed_necessitation d
+def preboxed_necessitation (d : □⁻¹Γ ⊢ p) : Γ ⊢ □p := weakening' (by simp; rfl) $ boxed_necessitation d
 
 @[inference]
 def preboxed_necessitation! (d : □⁻¹Γ ⊢! p) : Γ ⊢! □p := ⟨preboxed_necessitation d.some⟩

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -141,11 +141,10 @@ lemma axiomK'! (d₁ : Γ ⊢! (□(p ⟶ q))) (d₂ : Γ ⊢! □p) : Γ ⊢! �
 
 @[tautology]
 def box_distribute_iff : Γ ⊢ □(p ⟷ q) ⟶ (□p ⟷ □q) := by
-  have : (Set.box {p ⟷ q}) ⊢ (□p ⟶ □q) := box_distribute' $ boxed_necessitation $ iff_mp' $ axm (by simp);
-  have : (Set.box {p ⟷ q}) ⊢ (□q ⟶ □p) := box_distribute' $ boxed_necessitation $ iff_mpr' $ axm (by simp);
-  have : (Set.box {p ⟷ q}) ⊢ (□p ⟷ □q) := by deduct;
-  have : ({□(p ⟷ q)}) ⊢ (□p ⟷ □q) := by sorry; -- simpa [Set.multibox] using this;
-  have : ∅ ⊢ (□(p ⟷ q) ⟶ (□p ⟷ □q)) := dtr' (by deduct);
+  have : (□({p ⟷ q} : Set F)) ⊢ (□p ⟶ □q) := box_distribute' $ boxed_necessitation $ iff_mp' $ axm (by simp);
+  have : (□({p ⟷ q} : Set F)) ⊢ (□q ⟶ □p) := box_distribute' $ boxed_necessitation $ iff_mpr' $ axm (by simp);
+  have : (□({p ⟷ q} : Set F)) ⊢ (□p ⟷ □q) := iff_intro' (by assumption) (by assumption)
+  have : ∅ ⊢ (□(p ⟷ q) ⟶ (□p ⟷ □q)) := dtr' (by simpa using this);
   deduct;
 
 @[inference]
@@ -411,7 +410,7 @@ lemma distribute_multidia_list_conj'! {Γ : Set F} {Δ : List F} (d : Γ ⊢! �
 lemma distribute_multidia_finset_conj'! {Γ : Set F} {Δ : Finset F} (d : Γ ⊢! ◇[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
   apply finset_conj_iff!.mpr;
   intro p hp;
-  exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simp [Finset.multidia] at hp; sorry;);
+  exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simpa [Finset.multidia, List.multidia] using hp);
 
 lemma distribute_dia_finset_conj'! {Δ : Finset F} (d : Γ ⊢! ◇(Δ.conj)) : Γ ⊢! Δ.dia.conj := by
   have : (Γ ⊢! ◇[1]Δ.conj) → (Γ ⊢! (Δ.multidia 1).conj) := distribute_multidia_finset_conj'!;

--- a/Logic/Modal/Normal/HilbertStyle.lean
+++ b/Logic/Modal/Normal/HilbertStyle.lean
@@ -6,7 +6,7 @@ namespace LO.Hilbert
 
 open LO.Deduction LO.Modal.Normal
 
-variable {F : Type u} [ModalLogicSymbol F] [DecidableEq F] [NegDefinition F] (Bew : Set F → F → Type u)
+variable {F : Type u} [StandardModalLogicalConnective F] [DecidableEq F] [NegDefinition F] (Bew : Set F → F → Type u)
 
 class HasNecessitation where
   necessitation {Γ p} : (Bew ∅ p) → (Bew Γ (□p))
@@ -60,7 +60,6 @@ variable {Bew : Set F → F → Type u}
 local infixr:50 " ⊢ " => Bew
 local infixr:50 " ⊢! " => Deducible Bew
 
-variable [ModalDuality F] [ModalInjective F]
 variable [HasDT Bew] [Minimal Bew] [Classical Bew]
 variable [HasNecessitation Bew] [HasBoxedNecessitation Bew]
 variable [HasAxiomK Bew]
@@ -69,8 +68,7 @@ variable {Γ Δ : Set F} {p q r : F} {n m : ℕ}
 open HasNecessitation
 open HasBoxedNecessitation
 open HasAxiomK
-
-attribute [aesop 2 (rule_sets := [Deduction]) safe] ModalDuality.dia_to_box
+open StandardModalLogicalConnective
 
 @[inference]
 def necessitation (d : ∅ ⊢ p) : Γ ⊢ □p := HasNecessitation.necessitation d
@@ -91,10 +89,10 @@ def boxed_necessitation (d : Γ ⊢ p) : Γ.box ⊢ □p := HasBoxedNecessitatio
 def boxed_necessitation! (d : Γ ⊢! p) : Γ.box ⊢! □p := ⟨boxed_necessitation d.some⟩
 
 @[inference]
-def preboxed_necessitation (d : Γ.prebox ⊢ p) : Γ ⊢ □p := weakening' Set.prebox_box_subset $ boxed_necessitation d
+def preboxed_necessitation (d : □⁻¹Γ ⊢ p) : Γ ⊢ □p := weakening' (by simp) $ boxed_necessitation d
 
 @[inference]
-def preboxed_necessitation! (d : Γ.prebox ⊢! p) : Γ ⊢! □p := ⟨preboxed_necessitation d.some⟩
+def preboxed_necessitation! (d : □⁻¹Γ ⊢! p) : Γ ⊢! □p := ⟨preboxed_necessitation d.some⟩
 
 @[tautology]
 def axiomK : Γ ⊢ □(p ⟶ q) ⟶ □p ⟶ □q := by apply HasAxiomK.K
@@ -146,7 +144,7 @@ def box_distribute_iff : Γ ⊢ □(p ⟷ q) ⟶ (□p ⟷ □q) := by
   have : (Set.box {p ⟷ q}) ⊢ (□p ⟶ □q) := box_distribute' $ boxed_necessitation $ iff_mp' $ axm (by simp);
   have : (Set.box {p ⟷ q}) ⊢ (□q ⟶ □p) := box_distribute' $ boxed_necessitation $ iff_mpr' $ axm (by simp);
   have : (Set.box {p ⟷ q}) ⊢ (□p ⟷ □q) := by deduct;
-  have : ({□(p ⟷ q)}) ⊢ (□p ⟷ □q) := by simpa [Set.multibox] using this;
+  have : ({□(p ⟷ q)}) ⊢ (□p ⟷ □q) := by sorry; -- simpa [Set.multibox] using this;
   have : ∅ ⊢ (□(p ⟷ q) ⟶ (□p ⟷ □q)) := dtr' (by deduct);
   deduct;
 
@@ -161,7 +159,7 @@ lemma box_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! (□p ⟷ □q) := ⟨box_iff' 
 
 @[inference]
 def dia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ (◇p ⟷ ◇q) := by
-  simp only [ModalDuality.dia_to_box];
+  simp only [duality];
   apply neg_iff';
   apply box_iff';
   apply neg_iff';
@@ -184,7 +182,7 @@ def multidia_iff' (h : ∅ ⊢ p ⟷ q) : Γ ⊢ ◇[n]p ⟷ ◇[n]q := by
   induction n generalizing Γ with
   | zero => deduct;
   | succ n ih =>
-    simp [ModalDuality.dia_to_box];
+    simp [duality];
     apply neg_iff';
     apply box_iff';
     apply neg_iff';
@@ -195,17 +193,17 @@ lemma multidia_iff'! (d : ∅ ⊢! p ⟷ q) : Γ ⊢! ◇[n]p ⟷ ◇[n]q := ⟨
 
 @[tautology]
 def box_duality : Γ ⊢ □p ⟷ ~(◇~p) := by
-  simp [ModalDuality.dia_to_box];
+  simp [duality];
   have d₁ : Γ ⊢ □p ⟷ (□~~p) := by deduct;
   have d₂ : Γ ⊢ (□~~p) ⟷ ~~(□~~p) := by deduct;
-  simpa [ModalDuality.dia_to_box] using iff_trans' d₁ d₂
+  simpa [duality] using iff_trans' d₁ d₂
 
 @[tautology]
 lemma box_duality! : Γ ⊢! □p ⟷ ~(◇~p) := ⟨box_duality⟩
 
 @[tautology]
 def dia_duality : Γ ⊢ ◇p ⟷ ~(□~p) := by
-  simp only [ModalDuality.dia_to_box];
+  simp only [duality];
   apply neg_iff';
   apply iff_id;
 
@@ -219,11 +217,11 @@ def multibox_duality : Γ ⊢ □[n]p ⟷ ~(◇[n](~p)) := by
   induction n generalizing Γ with
   | zero => deduct
   | succ n ih =>
-    simp [ModalDuality.dia_to_box];
+    simp [duality];
     exact iff_trans'
       (show Γ ⊢ □□[n]p ⟷ ~~(□~~(□[n]p)) by
         have : Γ ⊢ □(□[n]p) ⟷ ~(◇~(□[n]p)) := box_duality
-        simpa [ModalDuality.dia_to_box];
+        simpa [duality];
       )
       (by
         have : ∅ ⊢ ~~(□[n]p) ⟷ □[n]p := by deduct;
@@ -241,7 +239,7 @@ def multidia_duality : Γ ⊢ ◇[n]p ⟷ ~(□[n](~p)) := by
   induction n generalizing Γ with
   | zero => apply dn;
   | succ n ih =>
-    simp [ModalDuality.dia_to_box];
+    simp [duality];
     apply neg_iff';
     apply box_iff';
     exact iff_trans' (neg_iff' $ ih) (by deduct);
@@ -259,7 +257,7 @@ lemma multidia_duality! : Γ ⊢! ◇[n]p ⟷ ~(□[n](~p)) := ⟨multidia_duali
 
 @[tautology]
 def equiv_dianeg_negbox : Γ ⊢ ◇~p ⟷ ~(□p) := by
-  simp only [ModalDuality.dia_to_box];
+  simp only [duality];
   apply neg_iff';
   apply box_iff';
   apply iff_symm';
@@ -371,7 +369,7 @@ lemma collect_box_disj'! (d : Γ ⊢! □p ⋎ □q) : Γ ⊢! □(p ⋎ q) := �
 
 @[tautology]
 def distribute_dia_conj : Γ ⊢ ◇(p ⋏ q) ⟶ (◇p ⋏ ◇q) := by
-  simp [ModalDuality.dia_to_box];
+  simp [duality];
   apply contra₂';
   apply dtr';
   have : (insert (~(~(□~p) ⋏ ~(□~q))) Γ) ⊢ ~(~(□~p) ⋏ ~(□~q)) := by deduct;
@@ -391,7 +389,7 @@ def distribute_multidia_conj : Γ ⊢ ◇[n](p ⋏ q) ⟶ (◇[n]p ⋏ ◇[n]q) 
     have : ∅ ⊢ ~(◇[n]p ⋏ ◇[n]q) ⟶ ~(◇[n](p ⋏ q)) := contra₀' ih;
     have : ∅ ⊢ □~(◇[n]p ⋏ ◇[n]q) ⟶ □~(◇[n](p ⋏ q)) := box_imp' this;
     have : ∅ ⊢ ~(□~(◇[n](p ⋏ q))) ⟶ ~(□~(◇[n]p ⋏ ◇[n]q)) := contra₀' this;
-    have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ ◇(◇[n]p ⋏ ◇[n]q) := by simpa [ModalDuality.dia_to_box] using this;
+    have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ ◇(◇[n]p ⋏ ◇[n]q) := by simpa [duality] using this;
     have : ∅ ⊢ ◇(◇[n]p ⋏ ◇[n]q) ⟶ (◇◇[n]p ⋏ ◇◇[n]q) := distribute_dia_conj
     have : ∅ ⊢ ◇(◇[n](p ⋏ q)) ⟶ (◇[(n + 1)]p ⋏ ◇[(n + 1)]q) := imp_trans' (by assumption) this;
     deduct;
@@ -413,11 +411,11 @@ lemma distribute_multidia_list_conj'! {Γ : Set F} {Δ : List F} (d : Γ ⊢! �
 lemma distribute_multidia_finset_conj'! {Γ : Set F} {Δ : Finset F} (d : Γ ⊢! ◇[n]Δ.conj) : Γ ⊢! (Δ.multidia n).conj := by
   apply finset_conj_iff!.mpr;
   intro p hp;
-  exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simpa using hp);
+  exact list_conj_iff!.mp (distribute_multidia_list_conj'! d) p (by simpa [Finset.multidia] using hp);
 
 lemma distribute_dia_finset_conj'! {Δ : Finset F} (d : Γ ⊢! ◇(Δ.conj)) : Γ ⊢! Δ.dia.conj := by
   have : (Γ ⊢! ◇[1]Δ.conj) → (Γ ⊢! (Δ.multidia 1).conj) := distribute_multidia_finset_conj'!;
-  simp_all;
+  simp_all [Finset.multidia, Finset.dia];
 
 lemma distribute_multidia_finset_conj! {n : ℕ} {Γ : Set F} {Δ : Finset F} : Γ ⊢! ◇[n]Δ.conj ⟶ (Δ.multidia n).conj := by
   apply dtr'!;
@@ -426,7 +424,7 @@ lemma distribute_multidia_finset_conj! {n : ℕ} {Γ : Set F} {Δ : Finset F} : 
 
 @[tautology]
 def collect_dia_disj : Γ ⊢ ◇p ⋎ ◇q ⟶ ◇(p ⋎ q) := by
-  simp [ModalDuality.dia_to_box];
+  simp [duality];
   apply contra₁';
   apply dtr';
   apply conj_neg';
@@ -472,9 +470,9 @@ end
 
 section Logics
 
-variable {F : Type u} [ModalLogicSymbol F] [NegDefinition F] [ModalDuality F] [DecidableEq F] (Bew : Set F → F → Type u)
+variable {F : Type u} [StandardModalLogicalConnective F] [NegDefinition F] [DecidableEq F] (Bew : Set F → F → Type u)
 
-class K [ModalDuality F] extends Hilbert.Classical Bew, HasNecessitation Bew, HasAxiomK Bew
+class K extends Hilbert.Classical Bew, HasNecessitation Bew, HasAxiomK Bew
 
 class KD extends Hilbert.K Bew, HasAxiomD Bew
 

--- a/Logic/Modal/Normal/LogicSymbol.lean
+++ b/Logic/Modal/Normal/LogicSymbol.lean
@@ -5,20 +5,20 @@ namespace LO
 /--
   Finite many unary modal operators
 -/
-class UnaryModalOperator (m : ℕ) (F : Sort*) where
-  mop (i : Fin m) : F → F
+class UnaryModalOperator (ι : Type*) (F : Sort*) where
+  mop (i : ι) : F → F
   mop_injective {i} : Function.Injective (mop i)
 
 notation:76 "△[" i "]" p => UnaryModalOperator.mop i p
 
 namespace UnaryModalOperator
 
-variable [UnaryModalOperator m F]
-variable {i : Fin m} {p q : F}
+variable [UnaryModalOperator ι F]
+variable {i : ι} {p q : F}
 
 @[simp] lemma mop_injective' : (△[i]p) = (△[i]q) ↔ p = q := by constructor; intro h; exact mop_injective h; simp_all;
 
-def multimop (i : Fin m) (n : ℕ) (p : F) : F :=
+def multimop (i : ι) (n : ℕ) (p : F) : F :=
   match n with
   | 0 => p
   | n + 1 => △[i]((multimop i n p))
@@ -52,10 +52,10 @@ namespace Set
 open LO
 open UnaryModalOperator
 
-variable [UnaryModalOperator m F]
-variable {i : Fin m} {s t : Set F} {n : ℕ} {a : F}
+variable [UnaryModalOperator ι F]
+variable {i : ι} {s t : Set F} {n : ℕ} {a : F}
 
-protected def multimop (i : Fin m) (n : ℕ) (s : Set F) : Set F := (multimop i n) '' s
+protected def multimop (i : ι) (n : ℕ) (s : Set F) : Set F := (multimop i n) '' s
 notation:76 "△[" i:90 "]" "[" n:90 "]" s:max => Set.multimop i n s
 
 @[simp] lemma multimop_empty : △[i][n](∅ : Set F) = ∅ := by simp [Set.multimop]
@@ -80,7 +80,7 @@ lemma forall_multimop_of_subset_multimop (h : s ⊆ △[i][n]t) : ∀ p ∈ s, �
   use q;
   simp_all;
 
-protected def mop (i : Fin m) (s : Set F) : Set F := Set.multimop i 1 s
+protected def mop (i : ι) (s : Set F) : Set F := Set.multimop i 1 s
 notation:76 "△[" i "]" s => Set.mop i s
 
 @[simp] lemma mop_empty : (△[i](∅ : Set F)) = ∅ := by simp [Set.mop]
@@ -102,7 +102,7 @@ protected lemma mop_injective : Function.Injective (λ {s : Set F} => Set.mop i 
 lemma forall_mop_of_subset_mop (h : s ⊆ (Set.mop i t)) : ∀ p ∈ s, ∃ q ∈ t, p = △[i]q := forall_multimop_of_subset_multimop h
 
 
-@[simp] protected def premultimop (i : Fin m) (n : ℕ) (s : Set F) := (multimop i n) ⁻¹' s
+@[simp] protected def premultimop (i : ι) (n : ℕ) (s : Set F) := (multimop i n) ⁻¹' s
 notation:76 "△⁻¹[" i:90 "]" "[" n:90 "]" s:max => Set.premultimop i n s
 
 lemma multimop_premultimop_eq : △⁻¹[i][n](△[i][n]s) = s := by
@@ -134,7 +134,7 @@ lemma subset_multimop_iff_premulitimop_subset (h : s ⊆ (△[i][n]t)) : (△⁻
   simp_all;
 
 
-protected def premop (i : Fin m) (s : Set F) := Set.premultimop i 1 s
+protected def premop (i : ι) (s : Set F) := Set.premultimop i 1 s
 notation:76 "△⁻¹[" i "]" s => Set.premop i s
 
 @[simp] lemma mop_premop_eq : (△⁻¹[i]△[i]s) = s := by apply multimop_premultimop_eq;
@@ -157,23 +157,23 @@ namespace List
 open LO
 open UnaryModalOperator
 
-variable [UnaryModalOperator m F] [DecidableEq F]
-variable {i : Fin m} {n : ℕ} {l : List F}
+variable [UnaryModalOperator ι F] [DecidableEq F]
+variable {i : ι} {n : ℕ} {l : List F}
 
-@[simp] protected def multimop (i : Fin m) (n : ℕ) (l : List F) : List F := l.map (multimop i n)
+@[simp] protected def multimop (i : ι) (n : ℕ) (l : List F) : List F := l.map (multimop i n)
 notation "△[" i:90 "]" "[" n:90 "]" l:max => List.multimop i n l
 
-@[simp] protected def mop (i : Fin m) (l : List F) : List F := △[i][1]l
+@[simp] protected def mop (i : ι) (l : List F) : List F := △[i][1]l
 notation "△[" n:90 "]" l:max => List.mop n l
 
 @[simp] lemma multimop_empty : △[i][n]([] : List F) = [] := by simp [List.multimop]
 
 @[simp] lemma multimop_zero : △[i][0]l = l := by simp [List.multimop, multimop]
 
-def premultimop (i : Fin m) (n : ℕ) (l : List F) := l.filter (λ (p : F) => △[i][n]p ∈ l)
+def premultimop (i : ι) (n : ℕ) (l : List F) := l.filter (λ (p : F) => △[i][n]p ∈ l)
 notation "△⁻¹[" i:90 "]" "[" n:90 "]" l:max => List.premultimop i n l
 
-@[simp] def premop (i : Fin m) (l : List F) := △[i][1]l
+@[simp] def premop (i : ι) (l : List F) := △[i][1]l
 notation "△⁻¹[" i:90 "]" l:max => List.premop i l
 
 end List
@@ -184,13 +184,13 @@ namespace Finset
 open LO
 open UnaryModalOperator
 
-variable [UnaryModalOperator m F] [DecidableEq F]
-variable {i : Fin m} {n : ℕ} {s t : Finset F}
+variable [UnaryModalOperator ι F] [DecidableEq F]
+variable {i : ι} {n : ℕ} {s t : Finset F}
 
-@[simp] protected noncomputable def multimop (i : Fin m) (n : ℕ) (s : Finset F) : Finset F := (△[i][n](s.toList)).toFinset
+@[simp] protected noncomputable def multimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := (△[i][n](s.toList)).toFinset
 notation "△[" i:90 "]" "[" n:90 "]" s:max => Finset.multimop i n s
 
-@[simp] protected noncomputable def mop (i : Fin m) (s : Finset F) : Finset F := △[i][1]s
+@[simp] protected noncomputable def mop (i : ι) (s : Finset F) : Finset F := △[i][1]s
 notation "△[" i:90 "]" s:max => Finset.mop i s
 
 lemma multimop_def : (△[i][n]s : Finset F) = s.image (multimop i n) := by simp [List.multimop, List.toFinset_map];
@@ -207,10 +207,10 @@ lemma multimop_union : (△[i][n](s ∪ t) : Finset F) = (△[i][n]s ∪ △[i][
 lemma multimop_mem_coe {s : Finset F} : a ∈ Finset.multimop i n s ↔ a ∈ Set.multimop i n (↑s : Set F) := by
   constructor <;> simp_all [Set.multimop];
 
-@[simp] noncomputable def premultimop (i : Fin m) (n : ℕ) (s : Finset F) : Finset F := s.preimage (multimop i n) (by simp)
+@[simp] noncomputable def premultimop (i : ι) (n : ℕ) (s : Finset F) : Finset F := s.preimage (multimop i n) (by simp)
 notation "△⁻¹[" i:90 "]" "[" n:90 "]" s:max => Finset.premultimop i n s
 
-@[simp] noncomputable def premop (i : Fin m) (s : Finset F) : Finset F := △⁻¹[i][1]s
+@[simp] noncomputable def premop (i : ι) (s : Finset F) : Finset F := △⁻¹[i][1]s
 notation "△⁻¹[" i:90 "]" s:max => Finset.premop i s
 
 lemma premultimop_coe : ↑(△⁻¹[i][n]s : Finset F) = △⁻¹[i][n](↑s : Set F) := by apply Finset.coe_preimage;
@@ -229,86 +229,86 @@ namespace LO
 /--
   Standard modal logic, which has 2 modal unary operators `□`, `◇`, and `◇` is defined as dual of `□`
 -/
-class StandardModalLogicalConnective (F : Sort _) extends LogicalConnective F, UnaryModalOperator 2 F where
-  duality {p : F} : (mop 1) p = ~((mop 0) (~p))
+class StandardModalLogicalConnective (F : Sort _) extends LogicalConnective F, UnaryModalOperator Bool F where
+  duality {p : F} : (mop false) p = ~((mop true) (~p))
 
 namespace StandardModalLogicalConnective
 
 variable [hS : StandardModalLogicalConnective F] [DecidableEq F]
 
 @[match_pattern]
-abbrev box : F → F := hS.mop 0
+abbrev box : F → F := hS.mop true
 prefix:74 "□" => StandardModalLogicalConnective.box
 
 @[match_pattern]
-abbrev dia : F → F := hS.mop 1
+abbrev dia : F → F := hS.mop false
 prefix:74 "◇" => StandardModalLogicalConnective.dia
 
 lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply hS.duality
 
-abbrev multibox (n : ℕ) : F → F := hS.multimop 0 n
+abbrev multibox (n : ℕ) : F → F := hS.multimop true n
 notation:74 "□[" n:90 "]" p:80 => multibox n p
 
-abbrev multidia (n : ℕ) : F → F := hS.multimop 1 n
+abbrev multidia (n : ℕ) : F → F := hS.multimop false n
 notation:74 "◇[" n:90 "]" p:80 => multidia n p
 
 
-abbrev _root_.Set.multibox (n : ℕ) (s : Set F) : Set F := Set.multimop (0 : Fin 2) n s
+abbrev _root_.Set.multibox (n : ℕ) (s : Set F) : Set F := Set.multimop true n s
 notation "□[" n:90 "]" s:80 => Set.multibox n s
 
-abbrev _root_.Set.box (s : Set F) : Set F := Set.mop (0 : Fin 2) s
+abbrev _root_.Set.box (s : Set F) : Set F := Set.mop true s
 notation "□" s:80 => Set.box s
 
-abbrev _root_.Set.premultibox (n : ℕ) (s : Set F) : Set F := Set.premultimop (0 : Fin 2) n s
+abbrev _root_.Set.premultibox (n : ℕ) (s : Set F) : Set F := Set.premultimop true n s
 notation "□⁻¹[" n:90 "]" s:80 => Set.premultibox n s
 
-abbrev _root_.Set.prebox (s : Set F) : Set F := Set.premop (0 : Fin 2) s
+abbrev _root_.Set.prebox (s : Set F) : Set F := Set.premop true s
 notation "□⁻¹" s:80 => Set.prebox s
 
-abbrev _root_.Set.multidia (n : ℕ) (s : Set F) : Set F := Set.multimop (1 : Fin 2) n s
+abbrev _root_.Set.multidia (n : ℕ) (s : Set F) : Set F := Set.multimop false n s
 notation "◇[" n:90 "]" s:80 => Set.multidia n s
 
-abbrev _root_.Set.dia (s : Set F) : Set F := Set.mop (1 : Fin 2) s
+abbrev _root_.Set.dia (s : Set F) : Set F := Set.mop false s
 notation "◇" s:80 => Set.dia s
 
-abbrev _root_.Set.premultidia (n : ℕ) (s : Set F) : Set F := Set.premultimop (1 : Fin 2) n s
+abbrev _root_.Set.premultidia (n : ℕ) (s : Set F) : Set F := Set.premultimop false n s
 notation "◇⁻¹[" n:90 "]" s:80 => Set.premultidia n s
 
-abbrev _root_.Set.predia (s : Set F) : Set F := Set.premop (1 : Fin 2) s
+abbrev _root_.Set.predia (s : Set F) : Set F := Set.premop false s
 notation "◇⁻¹" s:80 => Set.predia s
 
 
-abbrev _root_.List.multibox (n : ℕ) (l : List F) : List F := List.multimop (0 : Fin 2) n l
+abbrev _root_.List.multibox (n : ℕ) (l : List F) : List F := List.multimop true n l
 
-abbrev _root_.List.box (l : List F) : List F := List.mop (0 : Fin 2) l
+abbrev _root_.List.box (l : List F) : List F := List.mop true l
 
-abbrev _root_.List.multidia (n : ℕ) (l : List F) : List F := List.multimop (1 : Fin 2) n l
+abbrev _root_.List.multidia (n : ℕ) (l : List F) : List F := List.multimop false n l
 
-abbrev _root_.List.dia (l : List F) : List F := List.mop (1 : Fin 2) l
+abbrev _root_.List.dia (l : List F) : List F := List.mop false l
 
 
-noncomputable abbrev _root_.Finset.multibox (n : ℕ) (s : Finset F) : Finset F := Finset.multimop (0 : Fin 2) n s
+noncomputable abbrev _root_.Finset.multibox (n : ℕ) (s : Finset F) : Finset F := Finset.multimop true n s
 notation "□[" n:90 "]" s:80 => Finset.multibox n s
 
-noncomputable abbrev _root_.Finset.box (s : Finset F) : Finset F := Finset.mop (0 : Fin 2) s
+noncomputable abbrev _root_.Finset.box (s : Finset F) : Finset F := Finset.mop true s
 notation "□" s:80 => Finset.box s
 
-noncomputable abbrev _root_.Finset.premultibox (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop (0 : Fin 2) n s
+noncomputable abbrev _root_.Finset.premultibox (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop true n s
 notation "□⁻¹[" n:90 "]" s:80 => Finset.premultibox n s
 
-noncomputable abbrev _root_.Finset.prebox (s : Finset F) : Finset F := Finset.premop (0 : Fin 2) s
+noncomputable abbrev _root_.Finset.prebox (s : Finset F) : Finset F := Finset.premop true s
 notation "□⁻¹" s:80 => Finset.prebox s
 
-noncomputable abbrev _root_.Finset.multidia (n : ℕ) (s : Finset F) : Finset F := Finset.multimop (1 : Fin 2) n s
+noncomputable abbrev _root_.Finset.multidia (n : ℕ) (s : Finset F) : Finset F := Finset.multimop false n s
 notation "◇[" n:90 "]" s:80 => Finset.multidia n s
 
-noncomputable abbrev _root_.Finset.dia (s : Finset F) : Finset F := Finset.mop (1 : Fin 2) s
+noncomputable abbrev _root_.Finset.dia (s : Finset F) : Finset F := Finset.mop false s
 notation "◇" s:80 => Finset.dia s
 
-noncomputable abbrev _root_.Finset.premultidia (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop (1 : Fin 2) n s
+noncomputable abbrev _root_.Finset.premultidia (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop false n s
 notation "◇⁻¹[" n:90 "]" s:80 => Finset.premultidia n s
 
-noncomputable abbrev _root_.Finset.predia (s : Finset F) : Finset F := Finset.premop (1 : Fin 2) s
+noncomputable abbrev _root_.Finset.predia (s : Finset F) : Finset F := Finset.premop false s
 notation "◇⁻¹" s:80 => Finset.predia s
 
 end StandardModalLogicalConnective

--- a/Logic/Modal/Normal/LogicSymbol.lean
+++ b/Logic/Modal/Normal/LogicSymbol.lean
@@ -37,7 +37,11 @@ lemma multimop_prepost : (△[i]△[i][n]p) = (△[i][n](△[i]p)) := by inducti
 
 end UnaryModalOperator
 
+end LO
+
 /-
+TODO: 可算無限個の様相演算子を考えたいのならば以下の定義を用意すればよいと思うが，現状では考えていないので保留
+
 class InfiniteUnaryModalOperator (F : Sort _) where
   mop (i : ℕ) : F → F
   mop_injective {i} : Function.Injective (mop i)
@@ -55,6 +59,8 @@ protected def multimop (i : Fin m) (n : ℕ) (s : Set F) : Set F := (multimop i 
 notation:76 "△[" i:90 "]" "[" n:90 "]" s:max => Set.multimop i n s
 
 @[simp] lemma multimop_empty : △[i][n](∅ : Set F) = ∅ := by simp [Set.multimop]
+
+@[simp] lemma multimop_singleton : △[i][n]({a} : Set F) = {△[i][n]a} := by simp [Set.multimop]
 
 @[simp] lemma multimop_zero : △[i][0]s = s := by simp [Set.multimop]
 
@@ -78,6 +84,8 @@ protected def mop (i : Fin m) (s : Set F) : Set F := Set.multimop i 1 s
 notation:76 "△[" i "]" s => Set.mop i s
 
 @[simp] lemma mop_empty : (△[i](∅ : Set F)) = ∅ := by simp [Set.mop]
+
+@[simp] lemma mop_singleton : (△[i]({a} : Set F)) = {△[i]a} := by simp [Set.mop]
 
 @[simp] lemma mop_mem_intro : a ∈ s → (△[i]a) ∈ (△[i]s) := by apply multimop_mem_intro;
 
@@ -215,6 +223,8 @@ lemma premultimop_multimop_eq_of_subset_multimop {s : Finset F} {t : Set F} (hs 
   exact Finset.coe_inj.mp this;
 
 end Finset
+
+namespace LO
 
 /--
   Standard modal logic, which has 2 modal unary operators `□`, `◇`, and `◇` is defined as dual of `□`

--- a/Logic/Modal/Normal/LogicSymbol.lean
+++ b/Logic/Modal/Normal/LogicSymbol.lean
@@ -237,80 +237,97 @@ namespace StandardModalLogicalConnective
 variable [hS : StandardModalLogicalConnective F] [DecidableEq F]
 
 @[match_pattern]
-abbrev box : F → F := hS.mop true
+abbrev box : F → F := UnaryModalOperator.mop true
 prefix:74 "□" => StandardModalLogicalConnective.box
 
 @[match_pattern]
-abbrev dia : F → F := hS.mop false
+abbrev dia : F → F := UnaryModalOperator.mop false
 prefix:74 "◇" => StandardModalLogicalConnective.dia
 
 lemma duality' {p : F} : (◇p) = ~(□(~p)) := by apply hS.duality
 
-abbrev multibox (n : ℕ) : F → F := hS.multimop true n
-notation:74 "□[" n:90 "]" p:80 => multibox n p
+abbrev multibox (n : ℕ) : F → F := UnaryModalOperator.multimop true n
+notation:74 "□[" n:90 "]" p:80 => StandardModalLogicalConnective.multibox n p
 
-abbrev multidia (n : ℕ) : F → F := hS.multimop false n
-notation:74 "◇[" n:90 "]" p:80 => multidia n p
+abbrev multidia (n : ℕ) : F → F := UnaryModalOperator.multimop false n
+notation:74 "◇[" n:90 "]" p:80 => StandardModalLogicalConnective.multidia n p
+
+end LO.StandardModalLogicalConnective
 
 
-abbrev _root_.Set.multibox (n : ℕ) (s : Set F) : Set F := Set.multimop true n s
+section
+
+variable [LO.StandardModalLogicalConnective F] [DecidableEq F]
+
+
+namespace Set
+
+abbrev multibox (n : ℕ) (s : Set F) : Set F := Set.multimop true n s
 notation "□[" n:90 "]" s:80 => Set.multibox n s
 
-abbrev _root_.Set.box (s : Set F) : Set F := Set.mop true s
+abbrev box (s : Set F) : Set F := Set.mop true s
 notation "□" s:80 => Set.box s
 
-abbrev _root_.Set.premultibox (n : ℕ) (s : Set F) : Set F := Set.premultimop true n s
+abbrev premultibox (n : ℕ) (s : Set F) : Set F := Set.premultimop true n s
 notation "□⁻¹[" n:90 "]" s:80 => Set.premultibox n s
 
-abbrev _root_.Set.prebox (s : Set F) : Set F := Set.premop true s
+abbrev prebox (s : Set F) : Set F := Set.premop true s
 notation "□⁻¹" s:80 => Set.prebox s
 
-abbrev _root_.Set.multidia (n : ℕ) (s : Set F) : Set F := Set.multimop false n s
+abbrev multidia (n : ℕ) (s : Set F) : Set F := Set.multimop false n s
 notation "◇[" n:90 "]" s:80 => Set.multidia n s
 
-abbrev _root_.Set.dia (s : Set F) : Set F := Set.mop false s
+abbrev dia (s : Set F) : Set F := Set.mop false s
 notation "◇" s:80 => Set.dia s
 
-abbrev _root_.Set.premultidia (n : ℕ) (s : Set F) : Set F := Set.premultimop false n s
+abbrev premultidia (n : ℕ) (s : Set F) : Set F := Set.premultimop false n s
 notation "◇⁻¹[" n:90 "]" s:80 => Set.premultidia n s
 
-abbrev _root_.Set.predia (s : Set F) : Set F := Set.premop false s
+abbrev predia (s : Set F) : Set F := Set.premop false s
 notation "◇⁻¹" s:80 => Set.predia s
 
-
-abbrev _root_.List.multibox (n : ℕ) (l : List F) : List F := List.multimop true n l
-
-abbrev _root_.List.box (l : List F) : List F := List.mop true l
-
-abbrev _root_.List.multidia (n : ℕ) (l : List F) : List F := List.multimop false n l
-
-abbrev _root_.List.dia (l : List F) : List F := List.mop false l
+end Set
 
 
-noncomputable abbrev _root_.Finset.multibox (n : ℕ) (s : Finset F) : Finset F := Finset.multimop true n s
+namespace List
+
+abbrev multibox (n : ℕ) (l : List F) : List F := List.multimop true n l
+
+abbrev box (l : List F) : List F := List.mop true l
+
+abbrev multidia (n : ℕ) (l : List F) : List F := List.multimop false n l
+
+abbrev dia (l : List F) : List F := List.mop false l
+
+end List
+
+
+namespace Finset
+
+noncomputable abbrev multibox (n : ℕ) (s : Finset F) : Finset F := Finset.multimop true n s
 notation "□[" n:90 "]" s:80 => Finset.multibox n s
 
-noncomputable abbrev _root_.Finset.box (s : Finset F) : Finset F := Finset.mop true s
+noncomputable abbrev box (s : Finset F) : Finset F := Finset.mop true s
 notation "□" s:80 => Finset.box s
 
-noncomputable abbrev _root_.Finset.premultibox (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop true n s
+noncomputable abbrev premultibox (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop true n s
 notation "□⁻¹[" n:90 "]" s:80 => Finset.premultibox n s
 
-noncomputable abbrev _root_.Finset.prebox (s : Finset F) : Finset F := Finset.premop true s
+noncomputable abbrev prebox (s : Finset F) : Finset F := Finset.premop true s
 notation "□⁻¹" s:80 => Finset.prebox s
 
-noncomputable abbrev _root_.Finset.multidia (n : ℕ) (s : Finset F) : Finset F := Finset.multimop false n s
+noncomputable abbrev multidia (n : ℕ) (s : Finset F) : Finset F := Finset.multimop false n s
 notation "◇[" n:90 "]" s:80 => Finset.multidia n s
 
-noncomputable abbrev _root_.Finset.dia (s : Finset F) : Finset F := Finset.mop false s
+noncomputable abbrev dia (s : Finset F) : Finset F := Finset.mop false s
 notation "◇" s:80 => Finset.dia s
 
-noncomputable abbrev _root_.Finset.premultidia (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop false n s
+noncomputable abbrev premultidia (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop false n s
 notation "◇⁻¹[" n:90 "]" s:80 => Finset.premultidia n s
 
-noncomputable abbrev _root_.Finset.predia (s : Finset F) : Finset F := Finset.premop false s
+noncomputable abbrev predia (s : Finset F) : Finset F := Finset.premop false s
 notation "◇⁻¹" s:80 => Finset.predia s
 
-end StandardModalLogicalConnective
+end Finset
 
-end LO
+end

--- a/Logic/Modal/Normal/LogicSymbol.lean
+++ b/Logic/Modal/Normal/LogicSymbol.lean
@@ -189,14 +189,15 @@ lemma multimop_def : (△[i][n]s : Finset F) = s.image (multimop i n) := by simp
 
 lemma multimop_coe : ↑(△[i][n]s : Finset F) = △[i][n](↑s : Set F) := by simp_all [Set.multimop, List.multimop]; rfl;
 
-lemma mop_coe : ↑(△[i]s : Finset F) = △[i](↑s : Set F) := by apply multimop_coe;
-
 @[simp] lemma multimop_zero : (△[i][0]s : Finset F) = s := by simp [-List.multimop]
 
 @[simp]
 lemma multimop_union : (△[i][n](s ∪ t) : Finset F) = (△[i][n]s ∪ △[i][n]t : Finset F) := by
   simp [List.toFinset_map, List.multimop];
   aesop;
+
+lemma multimop_mem_coe {s : Finset F} : a ∈ Finset.multimop i n s ↔ a ∈ Set.multimop i n (↑s : Set F) := by
+  constructor <;> simp_all [Set.multimop];
 
 @[simp] noncomputable def premultimop (i : Fin m) (n : ℕ) (s : Finset F) : Finset F := s.preimage (multimop i n) (by simp)
 notation "△⁻¹[" i:90 "]" "[" n:90 "]" s:max => Finset.premultimop i n s
@@ -285,6 +286,9 @@ notation "□" s:80 => Finset.box s
 noncomputable abbrev _root_.Finset.premultibox (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop (0 : Fin 2) n s
 notation "□⁻¹[" n:90 "]" s:80 => Finset.premultibox n s
 
+noncomputable abbrev _root_.Finset.prebox (s : Finset F) : Finset F := Finset.premop (0 : Fin 2) s
+notation "□⁻¹" s:80 => Finset.prebox s
+
 noncomputable abbrev _root_.Finset.multidia (n : ℕ) (s : Finset F) : Finset F := Finset.multimop (1 : Fin 2) n s
 notation "◇[" n:90 "]" s:80 => Finset.multidia n s
 
@@ -293,6 +297,9 @@ notation "◇" s:80 => Finset.dia s
 
 noncomputable abbrev _root_.Finset.premultidia (n : ℕ) (s : Finset F) : Finset F := Finset.premultimop (1 : Fin 2) n s
 notation "◇⁻¹[" n:90 "]" s:80 => Finset.premultidia n s
+
+noncomputable abbrev _root_.Finset.predia (s : Finset F) : Finset F := Finset.premop (1 : Fin 2) s
+notation "◇⁻¹" s:80 => Finset.predia s
 
 end StandardModalLogicalConnective
 

--- a/Logic/Modal/Normal/Semantics.lean
+++ b/Logic/Modal/Normal/Semantics.lean
@@ -62,13 +62,13 @@ lemma imp_def : (w ⊩ᴹ[M] p ⟶ q) ↔ (w ⊮ᴹ[M] p) ∨ (w ⊩ᴹ[M] q) :=
 @[simp] lemma neg_def' : (w ⊩ᴹ[M] ~p) ↔ (w ⊮ᴹ[M] p) := by simp [Satisfies];
 
 @[simp]
-lemma multibox_def : (w ⊩ᴹ[M] □[n]p) ↔ (∀ v, M.frame[n] w v → (v ⊩ᴹ[M] p)) := by
+lemma multibox_def : (w ⊩ᴹ[M] □^[n]p) ↔ (∀ v, M.frame[n] w v → (v ⊩ᴹ[M] p)) := by
   induction n generalizing w with
   | zero => simp;
   | succ n ih => aesop;
 
 @[simp]
-lemma multidia_def : (w ⊩ᴹ[M] ◇[n]p) ↔ (∃ v, M.frame[n] w v ∧ (v ⊩ᴹ[M] p)) := by
+lemma multidia_def : (w ⊩ᴹ[M] ◇^[n]p) ↔ (∃ v, M.frame[n] w v ∧ (v ⊩ᴹ[M] p)) := by
   induction n generalizing w with
   | zero => simp;
   | succ n ih => aesop;


### PR DESCRIPTION
例えば今後，1-arityの様相演算子を1つだけ持つ論理(Lax Logic?など)や2個より多く持つ論理(Bimodal logic)などを考えることに備えて（現状予定は無いが）言語を拡張出来るようにした．

これに伴って今まで`ModalLogicSymbol`は`StandardModalLogicalConnective`と命名した．Standardという命名が一般的かどうかはわからない．
