### PR TITLE
feat(Modal): Logics equivalent to `𝐆𝐋`

### DIFF
--- a/Logic/Modal/Standard/Deduction.lean
+++ b/Logic/Modal/Standard/Deduction.lean
@@ -8,46 +8,84 @@ namespace LO.Modal.Standard
 
 variable {α : Type*} [DecidableEq α]
 
+structure DeductionParameterRules where
+  nec : Bool
+  loeb : Bool
+  henkin : Bool
+
+namespace DeductionParameterRules
+
+abbrev le (R₁ R₂ : DeductionParameterRules) : Prop :=
+  R₁.nec ≤ R₂.nec ∧
+  R₁.loeb ≤ R₂.loeb ∧
+  R₁.henkin ≤ R₂.henkin
+
+instance : LE DeductionParameterRules where
+  le R₁ R₂ :=
+    R₁.nec ≤ R₂.nec ∧
+    R₁.loeb ≤ R₂.loeb ∧
+    R₁.henkin ≤ R₂.henkin
+
+variable {R₁ R₂ : DeductionParameterRules} (h : R₁ ≤ R₂ := by simpa)
+
+@[simp] lemma nec_le (hNec : R₁.nec = true) : R₂.nec = true := by apply h.1; assumption;
+@[simp] lemma loeb_le (hLoeb : R₁.loeb = true) : R₂.loeb = true := by apply h.2.1; assumption;
+@[simp] lemma henkin_le (hHenkin : R₁.henkin = true) : R₂.henkin = true := by apply h.2.2; assumption;
+
+end DeductionParameterRules
+
 /--
   Parameter for deduction system.
 -/
 structure DeductionParameter (α) where
   axiomSet : AxiomSet α
-  nec : Bool
-notation "Ax(" L ")" => DeductionParameter.axiomSet L
+  rules : DeductionParameterRules
+notation "Ax(" 𝓓 ")" => DeductionParameter.axiomSet 𝓓
 
 namespace DeductionParameter
 
-variable (L L₁ L₂ : DeductionParameter α)
+variable (𝓓 𝓓₁ 𝓓₂ : DeductionParameter α)
 
 class HasNec where
-  has_nec : L.nec = true := by rfl
+  has_nec : 𝓓.rules.nec = true := by rfl
+
+class HasLoebRule where
+  has_loeb : 𝓓.rules.loeb = true := by rfl
+
+class HasHenkinRule where
+  has_henkin : 𝓓.rules.henkin = true := by rfl
+
+class HasNecOnly extends HasNec 𝓓 where
+  not_has_loeb : 𝓓.rules.loeb = false := by rfl
+  not_has_henkin : 𝓓.rules.henkin = false := by rfl
 
 class IncludeK where
-  include_K : 𝗞 ⊆ Ax(L) := by intro; aesop;
+  include_K : 𝗞 ⊆ Ax(𝓓) := by intro; aesop;
 
 /--
-  Deduction system of `L` is normal modal Logic.
+  Deduction system of `L` is normal modal 𝓓ogic.
 -/
-class Normal extends HasNec L, IncludeK L
+class Normal extends HasNecOnly 𝓓, IncludeK 𝓓 where
 
 end DeductionParameter
 
 
-inductive Deduction (L : DeductionParameter α) : (Formula α) → Type _
-  | maxm {p}     : p ∈ Ax(L) → Deduction L p
-  | mdp {p q}    : Deduction L (p ⟶ q) → Deduction L p → Deduction L q
-  | nec {p}      : (L.nec = true) → Deduction L p → Deduction L (□p)
-  | verum        : Deduction L ⊤
-  | imply₁ p q   : Deduction L (p ⟶ q ⟶ p)
-  | imply₂ p q r : Deduction L ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r)
-  | conj₁ p q    : Deduction L (p ⋏ q ⟶ p)
-  | conj₂ p q    : Deduction L (p ⋏ q ⟶ q)
-  | conj₃ p q    : Deduction L (p ⟶ q ⟶ p ⋏ q)
-  | disj₁ p q    : Deduction L (p ⟶ p ⋎ q)
-  | disj₂ p q    : Deduction L (q ⟶ p ⋎ q)
-  | disj₃ p q r  : Deduction L ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r))
-  | dne p        : Deduction L (~~p ⟶ p)
+inductive Deduction (𝓓 : DeductionParameter α) : (Formula α) → Type _
+  | maxm {p}     : p ∈ Ax(𝓓) → Deduction 𝓓 p
+  | mdp {p q}    : Deduction 𝓓 (p ⟶ q) → Deduction 𝓓 p → Deduction 𝓓 q
+  | nec {p}      : (𝓓.rules.nec = true) → Deduction 𝓓 p → Deduction 𝓓 (□p)
+  | loeb {p}     : (𝓓.rules.loeb = true) → Deduction 𝓓 (□p ⟶ p) → Deduction 𝓓 p
+  | henkin {p}   : (𝓓.rules.henkin = true) → Deduction 𝓓 (□p ⟷ p) → Deduction 𝓓 p
+  | verum        : Deduction 𝓓 ⊤
+  | imply₁ p q   : Deduction 𝓓 (p ⟶ q ⟶ p)
+  | imply₂ p q r : Deduction 𝓓 ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r)
+  | conj₁ p q    : Deduction 𝓓 (p ⋏ q ⟶ p)
+  | conj₂ p q    : Deduction 𝓓 (p ⋏ q ⟶ q)
+  | conj₃ p q    : Deduction 𝓓 (p ⟶ q ⟶ p ⋏ q)
+  | disj₁ p q    : Deduction 𝓓 (p ⟶ p ⋎ q)
+  | disj₂ p q    : Deduction 𝓓 (q ⟶ p ⋎ q)
+  | disj₃ p q r  : Deduction 𝓓 ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r))
+  | dne p        : Deduction 𝓓 (~~p ⟶ p)
 
 namespace Deduction
 
@@ -55,9 +93,9 @@ open DeductionParameter
 
 instance : System (Formula α) (DeductionParameter α) := ⟨Deduction⟩
 
-variable {L L₁ L₂ : DeductionParameter α}
+variable {𝓓 𝓓₁ 𝓓₂ : DeductionParameter α}
 
-instance : System.Classical L where
+instance : System.Classical 𝓓 where
   mdp := mdp
   verum := verum
   imply₁ := imply₁
@@ -70,10 +108,14 @@ instance : System.Classical L where
   disj₃ := disj₃
   dne := dne
 
-def maxm_subset (hNec : L₁.nec ≤ L₂.nec) (hAx : Ax(L₁) ⊆ Ax(L₂)) : (L₁ ⊢ p) → (L₂ ⊢ p)
+def maxm_subset
+  (hRules : 𝓓₁.rules ≤ 𝓓₂.rules)
+  (hAx : Ax(𝓓₁) ⊆ Ax(𝓓₂)) : (𝓓₁ ⊢ p) → (𝓓₂ ⊢ p)
   | maxm h => maxm (hAx h)
-  | mdp ih₁ ih₂  => mdp (maxm_subset hNec hAx ih₁) (maxm_subset hNec hAx ih₂)
-  | nec p h      => nec (by aesop) $ maxm_subset hNec hAx h
+  | mdp ih₁ ih₂  => mdp (maxm_subset hRules hAx ih₁) (maxm_subset hRules hAx ih₂)
+  | nec b h      => nec (by apply hRules.1; assumption) $ maxm_subset hRules hAx h
+  | loeb b h     => loeb (by apply hRules.2.1; assumption) $ maxm_subset hRules hAx h
+  | henkin b h   => henkin (by apply hRules.2.2; assumption) $ maxm_subset hRules hAx h
   | verum        => verum
   | imply₁ _ _   => imply₁ _ _
   | imply₂ _ _ _ => imply₂ _ _ _
@@ -85,22 +127,28 @@ def maxm_subset (hNec : L₁.nec ≤ L₂.nec) (hAx : Ax(L₁) ⊆ Ax(L₂)) : (
   | disj₃ _ _ _  => disj₃ _ _ _
   | dne _        => dne _
 
-lemma maxm_subset! (hNec : L₁.nec ≤ L₂.nec) (hAx : Ax(L₁) ⊆ Ax(L₂)) (h : L₁ ⊢! p) : L₂ ⊢! p := ⟨maxm_subset hNec hAx h.some⟩
+lemma maxm_subset! (hRules : 𝓓₁.rules ≤ 𝓓₂.rules) (hAx : Ax(𝓓₁) ⊆ Ax(𝓓₂)) (h : 𝓓₁ ⊢! p) : 𝓓₂ ⊢! p := ⟨maxm_subset hRules hAx h.some⟩
 
 @[simp]
-lemma reducible_of_subset (hNec : L₁.nec ≤ L₂.nec) (hAx : Ax(L₁) ⊆ Ax(L₂) := by intro; aesop) : L₁ ≤ₛ L₂ := by
+lemma reducible_of_subset (hNec : 𝓓₁.rules ≤ 𝓓₂.rules) (hAx : Ax(𝓓₁) ⊆ Ax(𝓓₂) := by intro; aesop) : 𝓓₁ ≤ₛ 𝓓₂ := by
   intro p hp;
   apply maxm_subset! hNec hAx hp;
 
-instance [HasNec L] : System.Necessitation L where
+instance [HasNec 𝓓] : System.Necessitation 𝓓 where
   nec := nec HasNec.has_nec
 
-instance [IncludeK L] : System.HasAxiomK L where
+instance [HasLoebRule 𝓓] : System.LoebRule 𝓓 where
+  loeb := loeb HasLoebRule.has_loeb
+
+instance [HasHenkinRule 𝓓] : System.HenkinRule 𝓓 where
+  henkin := henkin HasHenkinRule.has_henkin
+
+instance [IncludeK 𝓓] : System.HasAxiomK 𝓓 where
   K _ _ := maxm $ Set.mem_of_subset_of_mem (IncludeK.include_K) (by simp);
 
-instance [Normal L] : System.K L where
+instance [Normal 𝓓] : System.K 𝓓 where
 
-noncomputable def inducition_with_nec [HasNec L]
+noncomputable def inducition_with_nec [HasNecOnly L]
   {motive  : (p : Formula α) → L ⊢ p → Sort*}
   (hMaxm   : ∀ {p}, (h : p ∈ Ax(L)) → motive p (maxm h))
   (hMdp    : ∀ {p q}, (hpq : L ⊢ p ⟶ q) → (hp : L ⊢ p) → motive (p ⟶ q) hpq → motive p hp → motive q (hpq ⨀ hp))
@@ -115,12 +163,14 @@ noncomputable def inducition_with_nec [HasNec L]
   (hDisj₂  : ∀ {p q}, motive (q ⟶ p ⋎ q) $ disj₂ p q)
   (hDisj₃  : ∀ {p q r}, motive ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r)) $ disj₃ p q r)
   (hDne    : ∀ {p}, motive (~~p ⟶ p) $ dne p)
-  : ∀ {p}, (d : L ⊢ p) → motive p d := by
+  : ∀ {p}, (d : 𝓓 ⊢ p) → motive p d := by
   intro p d;
   induction d with
   | maxm h => exact hMaxm h
   | mdp hpq hp ihpq ihp => exact hMdp hpq hp ihpq ihp
   | nec _ hp ihp => exact hNec hp ihp
+  | loeb => have : 𝓓.rules.loeb = false := HasNecOnly.not_has_loeb; simp_all;
+  | henkin => have : 𝓓.rules.henkin = false := HasNecOnly.not_has_henkin; simp_all;
   | _ => aesop
 
 /-
@@ -145,7 +195,7 @@ open DeductionParameter
 
 private abbrev NecOnly (Ax : AxiomSet α) : DeductionParameter α where
   axiomSet := Ax
-  nec := true
+  rules := ⟨true, false, false⟩
 
 protected abbrev K : DeductionParameter α := NecOnly 𝗞
 notation "𝐊" => DeductionParameter.K
@@ -231,33 +281,42 @@ instance : System.Ver (𝐕𝐞𝐫 : DeductionParameter α) where
 protected abbrev N : DeductionParameter α := NecOnly ∅
 notation "𝐍" => DeductionParameter.N
 
+protected abbrev K4H : DeductionParameter α := NecOnly (𝗞 ∪ 𝟰 ∪ 𝗛)
+notation "𝐊𝟒𝐇" => DeductionParameter.K4H
+instance : Normal (α := α) 𝐊𝟒𝐇 where
+
+protected abbrev K4Loeb : DeductionParameter α where
+  axiomSet := 𝗞 ∪ 𝟰
+  rules := ⟨true, true, false⟩
+notation "𝐊𝟒(𝐋)" => DeductionParameter.K4Loeb
+instance : IncludeK (α := α) 𝐊𝟒(𝐋) where
+instance : HasNec (α := α) 𝐊𝟒(𝐋) where
+instance : HasLoebRule (α := α) 𝐊𝟒(𝐋) where
+instance : System.K4Loeb (𝐊𝟒(𝐋) : DeductionParameter α) where
+  Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
+
+protected abbrev K4Henkin : DeductionParameter α where
+  axiomSet := 𝗞 ∪ 𝟰
+  rules := ⟨true, false, true⟩
+notation "𝐊𝟒(𝐇)" => DeductionParameter.K4Henkin
+instance : IncludeK (α := α) 𝐊𝟒(𝐇) where
+instance : HasNec (α := α) 𝐊𝟒(𝐇) where
+instance : HasHenkinRule (α := α) 𝐊𝟒(𝐇) where
+instance : System.K4Henkin (𝐊𝟒(𝐇) : DeductionParameter α) where
+  Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
+
+
 end DeductionParameter
-
-@[simp] lemma reducible_K_KT : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐓 := by simp
-
-@[simp] lemma reducible_K_KD : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐃 := by simp
-
-@[simp] lemma reducible_KT_S4 : (𝐊𝐓 : DeductionParameter α) ≤ₛ 𝐒𝟒 := by simp
-
-@[simp] lemma reducible_K4_S4 : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒 := by apply Deduction.reducible_of_subset (by simp);
-
-@[simp] lemma reducible_S4_S4Dot2 : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒.𝟐 := by simp
-
-@[simp] lemma reducible_S4_S4Dot3 : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒.𝟑 := by simp
-
-@[simp] lemma reducible_S4_S4Grz : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒𝐆𝐫𝐳 := by simp
-
-@[simp] lemma reducible_K_GL : (𝐊 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by simp
 
 open System
 
 lemma normal_reducible
   {𝓓₁ 𝓓₂ : DeductionParameter α} [𝓓₁.Normal] [𝓓₂.Normal]
-  (hsubset : ∀ {p : Formula α}, p ∈ Ax(𝓓₁) → 𝓓₂ ⊢! p) : (𝓓₁ : DeductionParameter α) ≤ₛ 𝓓₂ := by
+  (hMaxm : ∀ {p : Formula α}, p ∈ Ax(𝓓₁) → 𝓓₂ ⊢! p) : (𝓓₁ : DeductionParameter α) ≤ₛ 𝓓₂ := by
   apply System.reducible_iff.mpr;
   intro p h;
   induction h.some using Deduction.inducition_with_nec with
-  | hMaxm hp => exact hsubset hp;
+  | hMaxm hp => exact hMaxm hp;
   | hMdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
   | hNec hp ihp => exact Necessitation.nec! (ihp ⟨hp⟩)
   | _ =>
@@ -273,6 +332,28 @@ lemma normal_reducible
     | apply disj₃!;
     | apply dne!;
 
+lemma normal_reducible_subset {𝓓₁ 𝓓₂ : DeductionParameter α} [𝓓₁.Normal] [𝓓₂.Normal]
+  (hSubset : Ax(𝓓₁) ⊆ Ax(𝓓₂)) : (𝓓₁ : DeductionParameter α) ≤ₛ 𝓓₂ := by
+  apply normal_reducible;
+  intro p hp;
+  exact ⟨Deduction.maxm $ hSubset hp⟩;
+
+lemma reducible_K_KT : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐓 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
+lemma reducible_K_KD : (𝐊 : DeductionParameter α) ≤ₛ 𝐊𝐃 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
+lemma reducible_KT_S4 : (𝐊𝐓 : DeductionParameter α) ≤ₛ 𝐒𝟒 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
+lemma reducible_K4_S4 : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒 := by apply normal_reducible_subset; intro; aesop;
+
+lemma reducible_S4_S4Dot2 : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒.𝟐 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
+lemma reducible_S4_S4Dot3 : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒.𝟑 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
+lemma reducible_S4_S4Grz : (𝐒𝟒 : DeductionParameter α) ≤ₛ 𝐒𝟒𝐆𝐫𝐳 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
+lemma reducible_K_GL : (𝐊 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by apply normal_reducible_subset; simp only [Set.subset_union_left];
+
 lemma reducible_K4_Triv : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐓𝐫𝐢𝐯 := by
   apply normal_reducible;
   intro p hp;
@@ -286,5 +367,79 @@ lemma reducible_K4_GL : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by
   rcases hp with (hK | hFour)
   . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
   . obtain ⟨_, _, e⟩ := hFour; subst_vars; exact axiomFour!;
+
+lemma reducible_GL_K4Loeb : (𝐆𝐋 : DeductionParameter α) ≤ₛ 𝐊𝟒(𝐋) := by
+  apply System.reducible_iff.mpr;
+  intro p h;
+  induction h.some with
+  | maxm hp => sorry;
+  | mdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
+  | nec hp ihp => sorry;
+  | loeb => sorry;
+  | henkin => sorry;
+  | _ =>
+    try first
+    | apply verum!;
+    | apply imply₁!;
+    | apply imply₂!;
+    | apply conj₁!;
+    | apply conj₂!;
+    | apply conj₃!;
+    | apply disj₁!;
+    | apply disj₂!;
+    | apply disj₃!;
+    | apply dne!;
+
+lemma reducible_K4Loeb_K4Henkin : (𝐊𝟒(𝐋) : DeductionParameter α) ≤ₛ 𝐊𝟒(𝐇) := by
+  apply System.reducible_iff.mpr;
+  intro p h;
+  induction h.some with
+  | maxm hp => sorry;
+  | mdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
+  | nec hp ihp => sorry;
+  | loeb => sorry;
+  | henkin => sorry;
+  | _ =>
+    try first
+    | apply verum!;
+    | apply imply₁!;
+    | apply imply₂!;
+    | apply conj₁!;
+    | apply conj₂!;
+    | apply conj₃!;
+    | apply disj₁!;
+    | apply disj₂!;
+    | apply disj₃!;
+    | apply dne!;
+
+lemma reducible_K4Henkin_K4H : (𝐊𝟒(𝐇) : DeductionParameter α) ≤ₛ 𝐊𝟒𝐇 := by
+  apply System.reducible_iff.mpr;
+  intro p h;
+  induction h.some with
+  | maxm hp => sorry;
+  | mdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
+  | nec hp ihp => sorry;
+  | loeb => sorry;
+  | henkin => sorry;
+  | _ =>
+    try first
+    | apply verum!;
+    | apply imply₁!;
+    | apply imply₂!;
+    | apply conj₁!;
+    | apply conj₂!;
+    | apply conj₃!;
+    | apply disj₁!;
+    | apply disj₂!;
+    | apply disj₃!;
+    | apply dne!;
+
+lemma reducible_K4Henkin_GL : (𝐊𝟒𝐇 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by
+  apply normal_reducible;
+  intro p hp;
+  rcases hp with (hK | hFour) | hH
+  . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
+  . obtain ⟨_, _, e⟩ := hFour; subst_vars; exact axiomFour!;
+  . obtain ⟨_, _, e⟩ := hH; subst_vars; exact axiomH!;
 
 end LO.Modal.Standard

--- a/Logic/Modal/Standard/Deduction.lean
+++ b/Logic/Modal/Standard/Deduction.lean
@@ -421,7 +421,7 @@ lemma reducible_K4_GL : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by
   . obtain ⟨_, _, e⟩ := hFour; subst_vars; exact axiomFour!;
 
 -- Macintyre & Simmons (1973)
--- 𝐆𝐋 = 𝐊𝟒(𝐋) = 𝐊𝟒(𝐇) = 𝐊𝟒𝐇
+-- 𝐆𝐋 =ₛ 𝐊𝟒(𝐋) =ₛ 𝐊𝟒(𝐇) =ₛ 𝐊𝟒𝐇
 section GL
 
 lemma reducible_GL_K4Loeb : (𝐆𝐋 : DeductionParameter α) ≤ₛ 𝐊𝟒(𝐋) := by

--- a/Logic/Modal/Standard/Deduction.lean
+++ b/Logic/Modal/Standard/Deduction.lean
@@ -1,6 +1,3 @@
-import Logic.Logic.HilbertStyle.Basic
-import Logic.Logic.HilbertStyle.Supplemental
-import Logic.Modal.Standard.System
 import Logic.Modal.Standard.Formula
 import Logic.Modal.Standard.HilbertStyle
 
@@ -148,11 +145,38 @@ instance [IncludeK 𝓓] : System.HasAxiomK 𝓓 where
 
 instance [Normal 𝓓] : System.K 𝓓 where
 
-noncomputable def inducition_with_nec [HasNecOnly L]
-  {motive  : (p : Formula α) → L ⊢ p → Sort*}
-  (hMaxm   : ∀ {p}, (h : p ∈ Ax(L)) → motive p (maxm h))
-  (hMdp    : ∀ {p q}, (hpq : L ⊢ p ⟶ q) → (hp : L ⊢ p) → motive (p ⟶ q) hpq → motive p hp → motive q (hpq ⨀ hp))
-  (hNec    : ∀ {p}, (hp : L ⊢ p) → motive p hp → motive (□p) (nec HasNec.has_nec hp))
+noncomputable def inducition!
+  {motive  : (p : Formula α) → 𝓓 ⊢! p → Sort*}
+  (hMaxm   : ∀ {p}, (h : p ∈ Ax(𝓓)) → motive p ⟨maxm h⟩)
+  (hMdp    : ∀ {p q}, {hpq : 𝓓 ⊢! p ⟶ q} → {hp : 𝓓 ⊢! p} → motive (p ⟶ q) hpq → motive p hp → motive q ⟨mdp hpq.some hp.some⟩)
+  (hNec    : (hasNec : 𝓓.rules.nec) → ∀ {p}, {hp : 𝓓 ⊢! p} → motive p hp → motive (□p) ⟨(nec hasNec hp.some)⟩)
+  (hLoeb   : (hasLoeb : 𝓓.rules.loeb) → ∀ {p}, {hp : 𝓓 ⊢! □p ⟶ p} → motive (□p ⟶ p) hp → motive p ⟨loeb hasLoeb hp.some⟩)
+  (hHenkin : (hasHenkin : 𝓓.rules.henkin) → ∀ {p}, {hp : 𝓓 ⊢! □p ⟷ p} → motive (□p ⟷ p) hp → motive p ⟨henkin hasHenkin hp.some⟩)
+  (hVerum  : motive ⊤ ⟨verum⟩)
+  (hImply₁ : ∀ {p q}, motive (p ⟶ q ⟶ p) $ ⟨imply₁ p q⟩)
+  (hImply₂ : ∀ {p q r}, motive ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r) $ ⟨imply₂ p q r⟩)
+  (hConj₁  : ∀ {p q}, motive (p ⋏ q ⟶ p) $ ⟨conj₁ p q⟩)
+  (hConj₂  : ∀ {p q}, motive (p ⋏ q ⟶ q) $ ⟨conj₂ p q⟩)
+  (hConj₃  : ∀ {p q}, motive (p ⟶ q ⟶ p ⋏ q) $ ⟨conj₃ p q⟩)
+  (hDisj₁  : ∀ {p q}, motive (p ⟶ p ⋎ q) $ ⟨disj₁ p q⟩)
+  (hDisj₂  : ∀ {p q}, motive (q ⟶ p ⋎ q) $ ⟨disj₂ p q⟩)
+  (hDisj₃  : ∀ {p q r}, motive ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r)) $ ⟨disj₃ p q r⟩)
+  (hDne    : ∀ {p}, motive (~~p ⟶ p) $ ⟨dne p⟩)
+  : ∀ {p}, (d : 𝓓 ⊢! p) → motive p d := by
+  intro p d;
+  induction d.some with
+  | maxm h => exact hMaxm h
+  | mdp hpq hp ihpq ihp => exact hMdp (ihpq ⟨hpq⟩) (ihp ⟨hp⟩)
+  | nec has hp ihp => exact hNec has (ihp ⟨hp⟩)
+  | loeb has hp ihp => exact hLoeb has (ihp ⟨hp⟩)
+  | henkin has hp ihp => exact hHenkin has (ihp ⟨hp⟩)
+  | _ => aesop
+
+noncomputable def inducition_with_nec [HasNecOnly 𝓓]
+  {motive  : (p : Formula α) → 𝓓 ⊢ p → Sort*}
+  (hMaxm   : ∀ {p}, (h : p ∈ Ax(𝓓)) → motive p (maxm h))
+  (hMdp    : ∀ {p q}, (hpq : 𝓓 ⊢ p ⟶ q) → (hp : 𝓓 ⊢ p) → motive (p ⟶ q) hpq → motive p hp → motive q (mdp hpq hp))
+  (hNec    : ∀ {p}, (hp : 𝓓 ⊢ p) → motive p hp → motive (□p) (nec HasNec.has_nec hp))
   (hVerum  : motive ⊤ verum)
   (hImply₁ : ∀ {p q}, motive (p ⟶ q ⟶ p) $ imply₁ p q)
   (hImply₂ : ∀ {p q r}, motive ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r) $ imply₂ p q r)
@@ -171,6 +195,31 @@ noncomputable def inducition_with_nec [HasNecOnly L]
   | nec _ hp ihp => exact hNec hp ihp
   | loeb => have : 𝓓.rules.loeb = false := HasNecOnly.not_has_loeb; simp_all;
   | henkin => have : 𝓓.rules.henkin = false := HasNecOnly.not_has_henkin; simp_all;
+  | _ => aesop
+
+noncomputable def inducition_with_nec! [HasNecOnly 𝓓]
+  {motive  : (p : Formula α) → 𝓓 ⊢! p → Sort*}
+  (hMaxm   : ∀ {p}, (h : p ∈ Ax(𝓓)) → motive p ⟨maxm h⟩)
+  (hMdp    : ∀ {p q}, {hpq : 𝓓 ⊢! p ⟶ q} → {hp : 𝓓 ⊢! p} → motive (p ⟶ q) hpq → motive p hp → motive q (hpq ⨀ hp))
+  (hNec    : ∀ {p}, {hp : 𝓓 ⊢! p} → motive p hp → motive (□p) ⟨(nec HasNec.has_nec hp.some)⟩)
+  (hVerum  : motive ⊤ ⟨verum⟩)
+  (hImply₁ : ∀ {p q}, motive (p ⟶ q ⟶ p) $ ⟨imply₁ p q⟩)
+  (hImply₂ : ∀ {p q r}, motive ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r) $ ⟨imply₂ p q r⟩)
+  (hConj₁  : ∀ {p q}, motive (p ⋏ q ⟶ p) $ ⟨conj₁ p q⟩)
+  (hConj₂  : ∀ {p q}, motive (p ⋏ q ⟶ q) $ ⟨conj₂ p q⟩)
+  (hConj₃  : ∀ {p q}, motive (p ⟶ q ⟶ p ⋏ q) $ ⟨conj₃ p q⟩)
+  (hDisj₁  : ∀ {p q}, motive (p ⟶ p ⋎ q) $ ⟨disj₁ p q⟩)
+  (hDisj₂  : ∀ {p q}, motive (q ⟶ p ⋎ q) $ ⟨disj₂ p q⟩)
+  (hDisj₃  : ∀ {p q r}, motive ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r)) $ ⟨disj₃ p q r⟩)
+  (hDne    : ∀ {p}, motive (~~p ⟶ p) $ ⟨dne p⟩)
+  : ∀ {p}, (d : 𝓓 ⊢! p) → motive p d := by
+  intro p d;
+  induction d using Deduction.inducition! with
+  | hMaxm h => exact hMaxm h
+  | hMdp ihpq ihp => exact hMdp ihpq ihp
+  | hNec _ ihp => exact hNec ihp
+  | hLoeb => have : 𝓓.rules.loeb = false := HasNecOnly.not_has_loeb; simp_all;
+  | hHenkin => have : 𝓓.rules.henkin = false := HasNecOnly.not_has_henkin; simp_all;
   | _ => aesop
 
 /-
@@ -284,6 +333,9 @@ notation "𝐍" => DeductionParameter.N
 protected abbrev K4H : DeductionParameter α := NecOnly (𝗞 ∪ 𝟰 ∪ 𝗛)
 notation "𝐊𝟒𝐇" => DeductionParameter.K4H
 instance : Normal (α := α) 𝐊𝟒𝐇 where
+instance : System.K4H (𝐊𝟒𝐇 : DeductionParameter α) where
+  Four _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
+  H _ := Deduction.maxm $ Set.mem_of_subset_of_mem (by rfl) (by simp)
 
 protected abbrev K4Loeb : DeductionParameter α where
   axiomSet := 𝗞 ∪ 𝟰
@@ -315,10 +367,10 @@ lemma normal_reducible
   (hMaxm : ∀ {p : Formula α}, p ∈ Ax(𝓓₁) → 𝓓₂ ⊢! p) : (𝓓₁ : DeductionParameter α) ≤ₛ 𝓓₂ := by
   apply System.reducible_iff.mpr;
   intro p h;
-  induction h.some using Deduction.inducition_with_nec with
+  induction h using Deduction.inducition_with_nec! with
   | hMaxm hp => exact hMaxm hp;
-  | hMdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
-  | hNec hp ihp => exact Necessitation.nec! (ihp ⟨hp⟩)
+  | hMdp ihpq ihp => exact ihpq ⨀ ihp
+  | hNec ihp => exact Necessitation.nec! ihp
   | _ =>
     try first
     | apply verum!;
@@ -368,15 +420,22 @@ lemma reducible_K4_GL : (𝐊𝟒 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by
   . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
   . obtain ⟨_, _, e⟩ := hFour; subst_vars; exact axiomFour!;
 
+-- Macintyre & Simmons (1973)
+-- 𝐆𝐋 = 𝐊𝟒(𝐋) = 𝐊𝟒(𝐇) = 𝐊𝟒𝐇
+section GL
+
 lemma reducible_GL_K4Loeb : (𝐆𝐋 : DeductionParameter α) ≤ₛ 𝐊𝟒(𝐋) := by
   apply System.reducible_iff.mpr;
   intro p h;
-  induction h.some with
-  | maxm hp => sorry;
-  | mdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
-  | nec hp ihp => sorry;
-  | loeb => sorry;
-  | henkin => sorry;
+  induction h using Deduction.inducition! with
+  | hMaxm hp =>
+    rcases hp with (hK | hL)
+    . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
+    . obtain ⟨_, e⟩ := hL; subst_vars; exact axiomL!;
+  | hMdp ihpq ihp => exact ihpq ⨀ ihp;
+  | hNec _ ihp => exact Necessitation.nec! ihp;
+  | hLoeb _ ihp => exact LoebRule.loeb! ihp;
+  | hHenkin => simp_all only [Bool.false_eq_true];
   | _ =>
     try first
     | apply verum!;
@@ -393,12 +452,15 @@ lemma reducible_GL_K4Loeb : (𝐆𝐋 : DeductionParameter α) ≤ₛ 𝐊𝟒(�
 lemma reducible_K4Loeb_K4Henkin : (𝐊𝟒(𝐋) : DeductionParameter α) ≤ₛ 𝐊𝟒(𝐇) := by
   apply System.reducible_iff.mpr;
   intro p h;
-  induction h.some with
-  | maxm hp => sorry;
-  | mdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
-  | nec hp ihp => sorry;
-  | loeb => sorry;
-  | henkin => sorry;
+  induction h using Deduction.inducition! with
+  | hMaxm hp =>
+    rcases hp with (hK | hFour)
+    . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
+    . obtain ⟨_, e⟩ := hFour; subst_vars; exact axiomFour!;
+  | hMdp ihpq ihp => exact ihpq ⨀ ihp;
+  | hNec _ ihp => exact Necessitation.nec! ihp;
+  | hLoeb _ ihp => exact LoebRule.loeb! ihp;
+  | hHenkin => simp_all only [Bool.false_eq_true];
   | _ =>
     try first
     | apply verum!;
@@ -415,12 +477,15 @@ lemma reducible_K4Loeb_K4Henkin : (𝐊𝟒(𝐋) : DeductionParameter α) ≤�
 lemma reducible_K4Henkin_K4H : (𝐊𝟒(𝐇) : DeductionParameter α) ≤ₛ 𝐊𝟒𝐇 := by
   apply System.reducible_iff.mpr;
   intro p h;
-  induction h.some with
-  | maxm hp => sorry;
-  | mdp hpq hp ihpq ihp => exact (ihpq ⟨hpq⟩) ⨀ (ihp ⟨hp⟩)
-  | nec hp ihp => sorry;
-  | loeb => sorry;
-  | henkin => sorry;
+  induction h using Deduction.inducition! with
+  | hMaxm hp =>
+    rcases hp with (hK | hFour)
+    . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
+    . obtain ⟨_, e⟩ := hFour; subst_vars; exact axiomFour!;
+  | hMdp ihpq ihp => exact ihpq ⨀ ihp;
+  | hNec _ ihp => exact Necessitation.nec! ihp;
+  | hHenkin _ ihp => exact HenkinRule.henkin! ihp;
+  | hLoeb => simp_all only [Bool.false_eq_true];
   | _ =>
     try first
     | apply verum!;
@@ -441,5 +506,7 @@ lemma reducible_K4Henkin_GL : (𝐊𝟒𝐇 : DeductionParameter α) ≤ₛ 𝐆
   . obtain ⟨_, _, e⟩ := hK; subst_vars; exact axiomK!;
   . obtain ⟨_, _, e⟩ := hFour; subst_vars; exact axiomFour!;
   . obtain ⟨_, _, e⟩ := hH; subst_vars; exact axiomH!;
+
+end GL
 
 end LO.Modal.Standard

--- a/Logic/Modal/Standard/Formula.lean
+++ b/Logic/Modal/Standard/Formula.lean
@@ -272,6 +272,9 @@ notation "𝗩𝗲𝗿" => AxiomSet.Ver
 protected abbrev Tc : AxiomSet α := { Axioms.Tc p | p }
 notation "𝗧𝗰" => AxiomSet.Tc
 
+protected abbrev H : AxiomSet α := { Axioms.H p | p }
+notation "𝗛" => AxiomSet.H
+
 end AxiomSet
 
 end LO.Modal.Standard

--- a/Logic/Modal/Standard/Geach.lean
+++ b/Logic/Modal/Standard/Geach.lean
@@ -102,7 +102,7 @@ namespace DeductionParameter
 
 protected abbrev Geach (l : List Axioms.Geach.Taple) : DeductionParameter α where
   axiomSet := 𝗚𝗲(l)
-  nec := true
+  rules := ⟨true, false, false⟩
 notation "𝐆𝐞(" l ")" => DeductionParameter.Geach l
 instance instNormal : Normal (α := α) 𝐆𝐞(l) where
   include_K := by simp [AxiomSet.MultiGeach.subsetK]
@@ -113,7 +113,7 @@ namespace Geach
 lemma subset_axm (h : l₁ ⊆ l₂ := by simp_all) : (Ax(𝐆𝐞(l₁)) : AxiomSet α) ⊆ (Ax(𝐆𝐞(l₂)) : AxiomSet α) := by simp_all;
 
 @[simp]
-lemma reducible (h : l₁ ⊆ l₂ := by simp_all) : (𝐆𝐞(l₁) : DeductionParameter α) ≤ₛ 𝐆𝐞(l₂) := by simp_all;
+lemma reducible (h : l₁ ⊆ l₂ := by simp_all) : (𝐆𝐞(l₁) : DeductionParameter α) ≤ₛ 𝐆𝐞(l₂) := by sorry;
 
 end Geach
 

--- a/Logic/Modal/Standard/HilbertStyle.lean
+++ b/Logic/Modal/Standard/HilbertStyle.lean
@@ -413,4 +413,27 @@ private def axiomFour_of_L [HasAxiomL 𝓢] : 𝓢 ⊢ Axioms.Four p := by
 
 instance [HasAxiomL 𝓢] : HasAxiomFour 𝓢 := ⟨fun _ ↦ axiomFour_of_L⟩
 
+private def axiomL_of_K4Loeb [K4Loeb 𝓢] : 𝓢 ⊢ Axioms.L p := by
+  dsimp [Axioms.L];
+  sorry;
+instance [K4Loeb 𝓢] : HasAxiomL 𝓢 := ⟨fun _ ↦ axiomL_of_K4Loeb⟩
+
+
+def axiomH [HasAxiomH 𝓢] : 𝓢 ⊢ □(□p ⟷ p) ⟶ □p := HasAxiomH.H _
+@[simp] lemma axiomH! [HasAxiomH 𝓢] : 𝓢 ⊢! □(□p ⟷ p) ⟶ □p := ⟨axiomH⟩
+
+instance [HasAxiomH 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ FiniteContext.of axiomH⟩
+instance [HasAxiomH 𝓢] (Γ : Context F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ Context.of axiomH⟩
+
+
+instance [K4Henkin 𝓢] : LoebRule 𝓢 where
+  loeb h := by sorry
+
+instance [K4H 𝓢] : HenkinRule 𝓢 where
+  henkin h := by sorry
+
+private def axiomH_of_GL [GL 𝓢] : 𝓢 ⊢ Axioms.H p := by
+  exact impTrans (implyBoxDistribute' $ conj₁) axiomL
+instance [GL 𝓢] : HasAxiomH 𝓢 := ⟨fun _ ↦ axiomH_of_GL⟩
+
 end LO.System

--- a/Logic/Modal/Standard/HilbertStyle.lean
+++ b/Logic/Modal/Standard/HilbertStyle.lean
@@ -413,24 +413,35 @@ private def axiomFour_of_L [HasAxiomL 𝓢] : 𝓢 ⊢ Axioms.Four p := by
 
 instance [HasAxiomL 𝓢] : HasAxiomFour 𝓢 := ⟨fun _ ↦ axiomFour_of_L⟩
 
-private def axiomL_of_K4Loeb [K4Loeb 𝓢] : 𝓢 ⊢ Axioms.L p := by
-  dsimp [Axioms.L];
-  sorry;
-instance [K4Loeb 𝓢] : HasAxiomL 𝓢 := ⟨fun _ ↦ axiomL_of_K4Loeb⟩
-
-
 def axiomH [HasAxiomH 𝓢] : 𝓢 ⊢ □(□p ⟷ p) ⟶ □p := HasAxiomH.H _
 @[simp] lemma axiomH! [HasAxiomH 𝓢] : 𝓢 ⊢! □(□p ⟷ p) ⟶ □p := ⟨axiomH⟩
 
 instance [HasAxiomH 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ FiniteContext.of axiomH⟩
 instance [HasAxiomH 𝓢] (Γ : Context F 𝓢) : HasAxiomH Γ := ⟨fun _ ↦ Context.of axiomH⟩
 
+open LoebRule
+lemma LoebRule.loeb! [LoebRule 𝓢] : 𝓢 ⊢! □p ⟶ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨loeb hp⟩
+
+open HenkinRule
+lemma HenkinRule.henkin! [HenkinRule 𝓢] : 𝓢 ⊢! □p ⟷ p → 𝓢 ⊢! p := by rintro ⟨hp⟩; exact ⟨henkin hp⟩
+
+private def axiomL_of_K4Loeb [K4Loeb 𝓢] : 𝓢 ⊢ Axioms.L p := by
+  dsimp [Axioms.L];
+  generalize e : □(□p ⟶ p) ⟶ □p = q;
+  have d₁ : [□(□p ⟶ p), □q] ⊢[𝓢] □□(□p ⟶ p) ⟶ □□p := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
+  have d₂ : [□(□p ⟶ p), □q] ⊢[𝓢] □□p ⟶ □p := FiniteContext.weakening (by aesop) $ deductInv' axiomK;
+  have d₃ : 𝓢 ⊢ □(□p ⟶ p) ⟶ □□(□p ⟶ p) := axiomFour;
+  have : 𝓢 ⊢ □q ⟶ q := by
+    nth_rw 2 [←e]; apply deduct'; apply deduct;
+    exact d₂ ⨀ (d₁ ⨀ ((of d₃) ⨀ (FiniteContext.byAxm)));
+  exact loeb this;
+instance [K4Loeb 𝓢] : HasAxiomL 𝓢 := ⟨fun _ ↦ axiomL_of_K4Loeb⟩
 
 instance [K4Henkin 𝓢] : LoebRule 𝓢 where
-  loeb h := by sorry
+  loeb h := h ⨀ (henkin $ iffIntro (axiomK' $ nec h) axiomFour);
 
 instance [K4H 𝓢] : HenkinRule 𝓢 where
-  henkin h := by sorry
+  henkin h := (conj₁' h) ⨀ (axiomH ⨀ nec h);
 
 private def axiomH_of_GL [GL 𝓢] : 𝓢 ⊢ Axioms.H p := by
   exact impTrans (implyBoxDistribute' $ conj₁) axiomL

--- a/Logic/Modal/Standard/Kripke/Geach/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Geach/Completeness.lean
@@ -11,7 +11,7 @@ open Formula
 variable {Λ : AxiomSet α} [Inhabited α] [DecidableEq α]
 
 open Theory MaximalParametricConsistentTheory CanonicalFrame in
-lemma definability_canonicalFrame_GeachAxiom {L : DeductionParameter α} [L.HasNec] [includeK : L.IncludeK] [Inhabited (MCT L)] (hAx : 𝗴𝗲(t) ⊆ Ax(L)) : GeachConfluent t (CanonicalFrame L) := by
+lemma definability_canonicalFrame_GeachAxiom {L : DeductionParameter α} [L.HasNecOnly] [includeK : L.IncludeK] [Inhabited (MCT L)] (hAx : 𝗴𝗲(t) ⊆ Ax(L)) : GeachConfluent t (CanonicalFrame L) := by
   have : L.Normal := ⟨⟩;
 
   intro Ω₁ Ω₂ Ω₃ h;
@@ -42,7 +42,7 @@ lemma definability_canonicalFrame_GeachAxiom {L : DeductionParameter α} [L.HasN
   simp [multiframe_def_multibox];
   constructor <;> { intros; apply hΩ; simp_all; }
 
-lemma definability_canonicalFrame_multiGeachAxiom {L : DeductionParameter α} [L.HasNec] [Inhabited (MCT L)] (hAx : 𝗚𝗲(ts) ⊆ Ax(L)) : MultiGeachConfluent ts (CanonicalFrame L) := by
+lemma definability_canonicalFrame_multiGeachAxiom {L : DeductionParameter α} [L.HasNecOnly] [Inhabited (MCT L)] (hAx : 𝗚𝗲(ts) ⊆ Ax(L)) : MultiGeachConfluent ts (CanonicalFrame L) := by
   induction ts with
   | nil => simp [MultiGeachConfluent];
   | cons t ts ih =>

--- a/Logic/Modal/Standard/Kripke/Soundness.lean
+++ b/Logic/Modal/Standard/Kripke/Soundness.lean
@@ -4,7 +4,7 @@ import Logic.Modal.Standard.Deduction
 namespace LO.Modal.Standard.Kripke
 
 variable {α : Type u}
-         {L : DeductionParameter α} [L.HasNec]
+         {L : DeductionParameter α} [L.HasNecOnly]
 
 open Deduction
 open Formula Formula.Kripke

--- a/Logic/Modal/Standard/System.lean
+++ b/Logic/Modal/Standard/System.lean
@@ -42,11 +42,19 @@ protected abbrev M := (□◇p ⟶ ◇□p)
 
 protected abbrev L := □(□p ⟶ p) ⟶ □p
 
+protected abbrev H := □(□p ⟷ p) ⟶ □p
+
 end Axioms
 
 
 class Necessitation where
   nec {p : F} : 𝓢 ⊢ p → 𝓢 ⊢ □p
+
+class LoebRule where
+  loeb {p : F} : 𝓢 ⊢ □p ⟶ p → 𝓢 ⊢ p
+
+class HenkinRule where
+  henkin {p : F} : 𝓢 ⊢ □p ⟷ p → 𝓢 ⊢ p
 
 class HasAxiomK where
   K (p q : F) : 𝓢 ⊢ Axioms.K p q
@@ -84,6 +92,9 @@ class HasAxiomTc where
 class HasAxiomVer where
   Ver (p : F) : 𝓢 ⊢ Axioms.Ver p
 
+class HasAxiomH where
+  H (p : F) : 𝓢 ⊢ Axioms.H p
+
 class K extends Classical 𝓢, Necessitation 𝓢, HasAxiomK 𝓢
 
 class KT extends K 𝓢, HasAxiomT 𝓢
@@ -107,5 +118,11 @@ class GL extends K 𝓢, HasAxiomL 𝓢
 class Triv extends K 𝓢, HasAxiomT 𝓢, HasAxiomTc 𝓢
 
 class Ver extends K 𝓢, HasAxiomVer 𝓢
+
+class K4H extends K4 𝓢, HasAxiomH 𝓢
+
+class K4Loeb extends K4 𝓢, LoebRule 𝓢
+
+class K4Henkin extends K4 𝓢, HenkinRule 𝓢
 
 end LO.System

--- a/md/src/standard_modal/GL.md
+++ b/md/src/standard_modal/GL.md
@@ -2,7 +2,7 @@
 
 ## Logics Equivalent to GL
 
-Introduct to Henkin Axiom `𝗛`, Löb Rule `(𝐋)`, Henkin Rule `(𝐇)`.
+Introduct Henkin Axiom `𝗛`, Löb Rule `(𝐋)`, Henkin Rule `(𝐇)`.
 
 ```lean
 protected abbrev H := □(□p ⟷ p) ⟶ □p

--- a/md/src/standard_modal/GL.md
+++ b/md/src/standard_modal/GL.md
@@ -1,1 +1,32 @@
 # On Gödel-Löb Logic
+
+## Logics Equivalent to GL
+
+Introduct to Henkin Axiom `𝗛`, Löb Rule `(𝐋)`, Henkin Rule `(𝐇)`.
+
+```lean
+protected abbrev H := □(□p ⟷ p) ⟶ □p
+
+class LoebRule where
+  loeb {p : F} : 𝓢 ⊢ □p ⟶ p → 𝓢 ⊢ p
+
+class HenkinRule where
+  henkin {p : F} : 𝓢 ⊢ □p ⟷ p → 𝓢 ⊢ p
+```
+
+- `𝐊𝟒𝐇` is defined normal logic that axioms are `𝗞`, `𝟰`, `𝗛`.
+- `𝐊𝟒(𝐋)` is defined as `𝐊𝟒` extended `(𝐋)`.
+- `𝐊𝟒(𝐇)` is defined as `𝐊𝟒` extended `(𝐇)`.
+
+These logics are equivalent to `𝐆𝐋`.
+
+```lean
+lemma reducible_GL_K4Loeb : 𝐆𝐋 ≤ₛ 𝐊𝟒(𝐋)
+lemma reducible_K4Loeb_K4Henkin: 𝐊𝟒(𝐋) ≤ₛ 𝐊𝟒(𝐇)
+lemma reducible_K4Henkin_K4H : 𝐊𝟒(𝐇) ≤ₛ 𝐊𝟒𝐇
+lemma reducible_K4Henkin_GL : 𝐊𝟒𝐇 ≤ₛ 𝐆𝐋
+
+--- Obviously `𝐆𝐋 =ₛ 𝐊𝟒(𝐋) =ₛ 𝐊𝟒(𝐇) =ₛ 𝐊𝟒𝐇`, since transivity of `≤ₛ` and definition of `=ₛ`.
+```
+
+Note: `𝐊𝐇` (normal logic that axioms are `𝗞`, `𝗛`) is proper weak logic of `𝐆𝐋` and not Kripke complete.


### PR DESCRIPTION
様相論理の演繹体系に推論規則を増やして拡張するテストとして，次の事実を証明した．

Henkin公理`𝐇`，Löb規則`(𝐋)`，Henkin規則`(𝐇)`を導入する．

```
protected abbrev H := □(□p ⟷ p) ⟶ □p

class LoebRule where
  loeb {p : F} : 𝓢 ⊢ □p ⟶ p → 𝓢 ⊢ p

class HenkinRule where
  henkin {p : F} : 𝓢 ⊢ □p ⟷ p → 𝓢 ⊢ p
```

このとき`𝐆𝐋 =ₛ 𝐊𝟒(𝐋) =ₛ 𝐊𝟒(𝐇) =ₛ 𝐊𝟒𝐇`．

なお，`𝐊𝐇`はKripke完全ではない（らしい）．
