### PR TITLE
feat: Negation equivalence on System

### DIFF
--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -28,6 +28,16 @@ end Axioms
 class ModusPonens where
   mdp {p q : F} : 𝓢 ⊢ p ⟶ q → 𝓢 ⊢ p → 𝓢 ⊢ q
 
+
+/--
+  Negation `~p` is equivalent to `p ⟶ ⊥` on **system**.
+
+  This is weaker asssumption than _"introducing `~p` as an abbreviation of `p ⟶ ⊥`" (`NegAbbrev`)_.
+-/
+protected class NegationEquiv (𝓢 : S) where
+  neg_equiv {p} : 𝓢 ⊢ ~p ⟷ (p ⟶ ⊥)
+
+
 class Minimal extends ModusPonens 𝓢 where
   verum              : 𝓢 ⊢ ⊤
   imply₁ (p q : F)   : 𝓢 ⊢ p ⟶ q ⟶ p
@@ -71,13 +81,19 @@ class Classical extends Minimal 𝓢, HasDNE 𝓢
 
 variable {𝓢}
 
+
+namespace ModusPonens
+
 infixl:90 "⨀" => ModusPonens.mdp
 
-lemma ModusPonens.mdp! [ModusPonens 𝓢] : 𝓢 ⊢! p ⟶ q → 𝓢 ⊢! p → 𝓢 ⊢! q := by
+lemma mdp! [ModusPonens 𝓢] : 𝓢 ⊢! p ⟶ q → 𝓢 ⊢! p → 𝓢 ⊢! q := by
   rintro ⟨hpq⟩ ⟨hp⟩;
   exact ⟨hpq ⨀ hp⟩
 
 infixl:90 "⨀" => ModusPonens.mdp!
+
+end ModusPonens
+
 
 variable [Minimal 𝓢]
 
@@ -178,6 +194,23 @@ def impId (p : F) : 𝓢 ⊢ p ⟶ p := Minimal.imply₂ p (p ⟶ p) p ⨀ imply
 def iffId (p : F) : 𝓢 ⊢ p ⟷ p := conj₃' (impId p) (impId p)
 @[simp] def iff_id! : 𝓢 ⊢! p ⟷ p := ⟨iffId p⟩
 
+
+namespace NegationEquiv
+
+variable [System.NegationEquiv 𝓢]
+
+lemma neg_equiv! : 𝓢 ⊢! ~p ⟷ (p ⟶ ⊥) := ⟨NegationEquiv.neg_equiv⟩
+
+def neg_equiv'.mp : 𝓢 ⊢ ~p → 𝓢 ⊢ p ⟶ ⊥ := λ h => (conj₁' neg_equiv) ⨀ h
+def neg_equiv'.mpr : 𝓢 ⊢ p ⟶ ⊥ → 𝓢 ⊢ ~p := λ h => (conj₂' neg_equiv) ⨀ h
+lemma neg_equiv'! : 𝓢 ⊢! ~p ↔ 𝓢 ⊢! p ⟶ ⊥ := ⟨λ ⟨h⟩ => ⟨neg_equiv'.mp h⟩, λ ⟨h⟩ => ⟨neg_equiv'.mpr h⟩⟩
+
+instance [NegAbbrev F] : System.NegationEquiv 𝓢 where
+  neg_equiv := by intro p; simp [NegAbbrev.neg]; apply iffId;
+
+end NegationEquiv
+
+
 def mdp₁ (bqr : 𝓢 ⊢ p ⟶ q ⟶ r) (bq : 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ p ⟶ r := Minimal.imply₂ p q r ⨀ bqr ⨀ bq
 lemma mdp₁! (hqr : 𝓢 ⊢! p ⟶ q ⟶ r) (hq : 𝓢 ⊢! p ⟶ q) : 𝓢 ⊢! p ⟶ r := ⟨mdp₁ hqr.some hq.some⟩
 
@@ -273,5 +306,8 @@ def conjImplyConj [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ
   implyConj _ _ (fun _ hq ↦ generalConj (h hq))
 
 instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasEFQ 𝓢] : DeductiveExplosion S := ⟨fun b _ ↦ efq ⨀ b⟩
+
+
+
 
 end LO.System

--- a/Logic/Logic/HilbertStyle/Context.lean
+++ b/Logic/Logic/HilbertStyle/Context.lean
@@ -159,6 +159,8 @@ instance : StrongCut (FiniteContext F 𝓢) (FiniteContext F 𝓢) :=
     have : Γ ⊢ Δ.conj := conjIntro _ (fun _ hp ↦ bΓ hp)
     ofDef <| impTrans (toDef this) (toDef bΔ)⟩
 
+instance [System.NegationEquiv 𝓢] (Γ : FiniteContext F 𝓢) : System.NegationEquiv Γ := ⟨λ {_} => of NegationEquiv.neg_equiv⟩
+
 instance [HasEFQ 𝓢] (Γ : FiniteContext F 𝓢) : HasEFQ Γ := ⟨fun _ ↦ of efq⟩
 
 instance [HasWeakLEM 𝓢] (Γ : FiniteContext F 𝓢) : HasWeakLEM Γ := ⟨fun p ↦ of (HasWeakLEM.wlem p)⟩
@@ -310,6 +312,8 @@ instance minimal (Γ : Context F 𝓢) : Minimal Γ where
   disj₁ := fun _ _ ↦ of disj₁
   disj₂ := fun _ _ ↦ of disj₂
   disj₃ := fun _ _ _ ↦ of disj₃
+
+instance [System.NegationEquiv 𝓢] (Γ : Context F 𝓢) : System.NegationEquiv Γ := ⟨λ {_} => of NegationEquiv.neg_equiv⟩
 
 instance [HasEFQ 𝓢] (Γ : Context F 𝓢) : HasEFQ Γ := ⟨fun _ ↦ of efq⟩
 

--- a/Logic/Logic/HilbertStyle/Supplemental.lean
+++ b/Logic/Logic/HilbertStyle/Supplemental.lean
@@ -3,27 +3,30 @@ import Logic.Logic.HilbertStyle.Context
 
 namespace LO.System
 
-variable {F : Type*} [LogicalConnective F] [NegDefinition F] [DecidableEq F]
+variable {F : Type*} [LogicalConnective F] [DecidableEq F]
          {S : Type*} [System F S]
-         {𝓢 : S}
-         [Minimal 𝓢]
+         {𝓢 : S} [Minimal 𝓢]
          {p q r : F}
          {Γ Δ : List F}
 
+open NegationEquiv
 open FiniteContext
 
-def bot_of_mem_either (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢] ⊥ := by
-  exact (by simpa [NegDefinition.neg] using FiniteContext.byAxm h₂) ⨀ (FiniteContext.byAxm h₁);
-@[simp] lemma bot_of_mem_either! (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢]! ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
+def bot_of_mem_either [System.NegationEquiv 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢] ⊥ := by
+  have hp : Γ ⊢[𝓢] p := FiniteContext.byAxm h₁;
+  have hnp : Γ ⊢[𝓢] p ⟶ ⊥ := NegationEquiv.neg_equiv'.mp $ FiniteContext.byAxm h₂;
+  exact hnp ⨀ hp
+
+@[simp] lemma bot_of_mem_either! [System.NegationEquiv 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢]! ⊥ := ⟨bot_of_mem_either h₁ h₂⟩
 
 
-def efq_of_mem_either [HasEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢] q := efq' $ bot_of_mem_either h₁ h₂
-@[simp] lemma efq_of_mem_either! [HasEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢]! q := ⟨efq_of_mem_either h₁ h₂⟩
+def efq_of_mem_either [System.NegationEquiv 𝓢] [HasEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢] q := efq' $ bot_of_mem_either h₁ h₂
+@[simp] lemma efq_of_mem_either! [System.NegationEquiv 𝓢] [HasEFQ 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢]! q := ⟨efq_of_mem_either h₁ h₂⟩
 
-lemma efq_of_neg! [HasEFQ 𝓢] (h : 𝓢 ⊢! ~p) : 𝓢 ⊢! p ⟶ q := by
+lemma efq_of_neg! [System.NegationEquiv 𝓢] [HasEFQ 𝓢] (h : 𝓢 ⊢! ~p) : 𝓢 ⊢! p ⟶ q := by
   apply provable_iff_provable.mpr;
   apply deduct_iff.mpr;
-  have dnp : [p] ⊢[𝓢]! p ⟶ ⊥ := by simpa [NegDefinition.neg] using of'! h;
+  have dnp : [p] ⊢[𝓢]! p ⟶ ⊥ := of'! $ neg_equiv'!.mp h;
   exact efq'! (dnp ⨀ FiniteContext.id!);
 
 
@@ -118,9 +121,11 @@ def impReplaceIff (hp : 𝓢 ⊢ p₁ ⟷ p₂) (hq : 𝓢 ⊢ q₁ ⟷ q₂) : 
 lemma imp_replace_iff! (hp : 𝓢 ⊢! p₁ ⟷ p₂) (hq : 𝓢 ⊢! q₁ ⟷ q₂) : 𝓢 ⊢! (p₁ ⟶ q₁) ⟷ (p₂ ⟶ q₂) := ⟨impReplaceIff hp.some hq.some⟩
 
 
+variable [System.NegationEquiv 𝓢]
+
 def dni : 𝓢 ⊢ p ⟶ ~~p := by
-  rw [NegDefinition.neg];
   apply deduct';
+  apply neg_equiv'.mpr;
   apply deduct;
   exact bot_of_mem_either (p := p) (by simp) (by simp);
 @[simp] lemma dni! : 𝓢 ⊢! p ⟶ ~~p := ⟨dni⟩
@@ -141,14 +146,15 @@ def dn [HasDNE 𝓢] : 𝓢 ⊢ p ⟷ ~~p := iffIntro dni dne
 
 
 def contra₀ : 𝓢 ⊢ (p ⟶ q) ⟶ (~q ⟶ ~p) := by
-  simp [NegDefinition.neg];
   apply deduct';
   apply deduct;
+  apply neg_equiv'.mpr;
   apply deduct;
-  have d₁ : [p, q ⟶ ⊥, p ⟶ q] ⊢[𝓢] p := FiniteContext.byAxm;
-  have d₂ : [p, q ⟶ ⊥, p ⟶ q] ⊢[𝓢] q ⟶ ⊥ := FiniteContext.byAxm;
-  have d₃ : [p, q ⟶ ⊥, p ⟶ q] ⊢[𝓢] p ⟶ q := FiniteContext.byAxm;
-  exact d₂ ⨀ (d₃ ⨀ d₁);
+  have dp  : [p, ~q, p ⟶ q] ⊢[𝓢] p := FiniteContext.byAxm;
+  have dpq : [p, ~q, p ⟶ q] ⊢[𝓢] p ⟶ q := FiniteContext.byAxm;
+  have dq  : [p, ~q, p ⟶ q] ⊢[𝓢] q := dpq ⨀ dp;
+  have dnq : [p, ~q, p ⟶ q] ⊢[𝓢] q ⟶ ⊥ := neg_equiv'.mp $ FiniteContext.byAxm;
+  exact dnq ⨀ dq;
 @[simp] def contra₀! : 𝓢 ⊢! (p ⟶ q) ⟶ (~q ⟶ ~p) := ⟨contra₀⟩
 
 def contra₀' (b : 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ ~q ⟶ ~p := contra₀ ⨀ b
@@ -232,9 +238,7 @@ noncomputable def dnDistributeImply' (b : 𝓢 ⊢ ~~(p ⟶ q)) : 𝓢 ⊢ ~~p �
 lemma dn_distribute_imply'! (b : 𝓢 ⊢! ~~(p ⟶ q)) : 𝓢 ⊢! ~~p ⟶ ~~q := ⟨dnDistributeImply' b.some⟩
 
 
-def introFalsumOfAnd' (h : 𝓢 ⊢ p ⋏ ~p) : 𝓢 ⊢ ⊥ := by
-  simp [NegDefinition.neg] at h;
-  exact (conj₂' h) ⨀ (conj₁' h)
+def introFalsumOfAnd' (h : 𝓢 ⊢ p ⋏ ~p) : 𝓢 ⊢ ⊥ := (neg_equiv'.mp $ conj₂' h) ⨀ (conj₁' h)
 lemma introFalsumOfAnd'! (h : 𝓢 ⊢! p ⋏ ~p) : 𝓢 ⊢! ⊥ := ⟨introFalsumOfAnd' h.some⟩
 
 def introFalsumOfAnd : 𝓢 ⊢ p ⋏ ~p ⟶ ⊥ := by
@@ -265,7 +269,11 @@ lemma demorgan₁'! (d : 𝓢 ⊢! ~p ⋎ ~q) : 𝓢 ⊢! ~(p ⋏ q) := ⟨demor
 
 def demorgan₂ : 𝓢 ⊢ (~p ⋏ ~q) ⟶ ~(p ⋎ q) := by
   apply andImplyIffImplyImply'.mpr;
-  simpa [NegDefinition.neg] using disj₃;
+  apply deduct';
+  apply deduct;
+  apply neg_equiv'.mpr;
+  apply deduct;
+  exact disj₃' (neg_equiv'.mp FiniteContext.byAxm) (neg_equiv'.mp FiniteContext.byAxm) (FiniteContext.byAxm (p := p ⋎ q));
 @[simp] lemma demorgan₂! : 𝓢 ⊢! ~p ⋏ ~q ⟶ ~(p ⋎ q) := ⟨demorgan₂⟩
 
 def demorgan₂' (d : 𝓢 ⊢ ~p ⋏ ~q) : 𝓢 ⊢ ~(p ⋎ q) := demorgan₂ ⨀ d
@@ -294,10 +302,10 @@ lemma demorgan₄'! [HasDNE 𝓢] (b : 𝓢 ⊢! ~(p ⋏ q)) : 𝓢 ⊢! ~p ⋎ 
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def NotOrOfImply' [HasDNE 𝓢] (d : 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ ~p ⋎ q := by
   apply dne';
-  rw [NegDefinition.neg];
+  apply neg_equiv'.mpr;
   apply deduct';
   have d₁ : [~(~p ⋎ q)] ⊢[𝓢] ~~p ⋏ ~q := demorgan₃' $ FiniteContext.id;
-  have d₂ : [~(~p ⋎ q)] ⊢[𝓢] ~p ⟶ ⊥ := by simpa only [NegDefinition.neg] using conj₁' d₁;
+  have d₂ : [~(~p ⋎ q)] ⊢[𝓢] ~p ⟶ ⊥ := neg_equiv'.mp $ conj₁' d₁;
   have d₃ : [~(~p ⋎ q)] ⊢[𝓢] ~p := (of (Γ := [~(~p ⋎ q)]) $ contra₀' d) ⨀ (conj₂' d₁);
   exact d₂ ⨀ d₃;
 lemma NotOrOfImply'! [HasDNE 𝓢] (d : 𝓢 ⊢! p ⟶ q) : 𝓢 ⊢! ~p ⋎ q := ⟨NotOrOfImply' d.some⟩
@@ -305,13 +313,12 @@ lemma NotOrOfImply'! [HasDNE 𝓢] (d : 𝓢 ⊢! p ⟶ q) : 𝓢 ⊢! ~p ⋎ q 
 -- TODO: Actually this can be computable but it's too slow.
 noncomputable def dnCollectImply [HasEFQ 𝓢] : 𝓢 ⊢ (~~p ⟶ ~~q) ⟶ ~~(p ⟶ q) := by
   apply deduct';
-  nth_rw 5 [NegDefinition.neg];
+  apply neg_equiv'.mpr;
   exact impTrans
     (by
       apply deductInv;
       apply andImplyIffImplyImply'.mp;
       apply deduct;
-
       have d₁ : [(~~p ⟶ ~~q) ⋏ ~(p ⟶ q)] ⊢[𝓢] ~~p ⟶ ~~q := conj₁' (q := ~(p ⟶ q)) $ FiniteContext.id;
       have d₂ : [(~~p ⟶ ~~q) ⋏ ~(p ⟶ q)] ⊢[𝓢] ~~p ⋏ ~q := demorgan₃' $ (contra₀' implyOfNotOr) ⨀ (conj₂' (p := (~~p ⟶ ~~q)) $ FiniteContext.id)
       exact conj₃' (conj₂' d₂) (d₁ ⨀ (conj₁' d₂))
@@ -616,9 +623,7 @@ lemma disj_allsame'! [HasEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) (h : 𝓢 ⊢! Γ.
 instance [HasDNE 𝓢] : HasEFQ 𝓢 where
   efq p := by
     apply contra₃';
-    simp [NegDefinition.neg];
-    exact impSwap' imply₁;
-
+    exact impTrans (conj₁' neg_equiv) $ impTrans (impSwap' imply₁) (conj₂' neg_equiv);
 
 def dneOr [HasDNE 𝓢] (d : 𝓢 ⊢ ~~p ⋎ ~~q) : 𝓢 ⊢ p ⋎ q := disj₃' (impTrans dne disj₁) (impTrans dne disj₂) d
 
@@ -631,7 +636,7 @@ instance [HasEFQ 𝓢] [HasLEM 𝓢] : HasDNE 𝓢 where
     apply deduct';
     exact disj₃' (impId _) (by
       apply deduct;
-      have nnp : [~p, ~~p] ⊢[𝓢] ~p ⟶ ⊥ := by simpa [NegDefinition.neg] using FiniteContext.byAxm;
+      have nnp : [~p, ~~p] ⊢[𝓢] ~p ⟶ ⊥ := neg_equiv'.mp $ FiniteContext.byAxm;
       have np : [~p, ~~p] ⊢[𝓢] ~p := FiniteContext.byAxm;
       exact efq' $ nnp ⨀ np;
     ) $ of lem;;

--- a/Logic/Logic/LogicSymbol.lean
+++ b/Logic/Logic/LogicSymbol.lean
@@ -274,8 +274,10 @@ class DeMorgan (F : Type*) [LogicalConnective F] where
 
 attribute [simp] DeMorgan.verum DeMorgan.falsum DeMorgan.and DeMorgan.or DeMorgan.neg
 
-class NegDefinition (F : Type*) [LogicalConnective F] where
+/-- Introducing `~p` as an abbreviation of `p ⟶ ⊥`. -/
+class NegAbbrev (F : Type*) [Tilde F] [Arrow F] [Bot F] where
   neg {p : F} : ~p = p ⟶ ⊥
+attribute [simp] NegAbbrev.neg
 
 namespace LogicalConnective
 

--- a/Logic/Modal/Standard/Formula.lean
+++ b/Logic/Modal/Standard/Formula.lean
@@ -35,7 +35,7 @@ instance : StandardModalLogicalConnective (Formula α) where
   mop_injective := by simp_all [Function.Injective]
   duality := by simp;
 
-instance : NegDefinition (Formula α) where
+instance : NegAbbrev (Formula α) where
   neg := rfl
 
 section ToString
@@ -77,7 +77,7 @@ lemma dia_eq (p : Formula α) : ◇p = ~(□(~p)) := rfl
 
 @[simp] lemma imp_inj (p₁ q₁ p₂ q₂ : Formula α) : p₁ ⟶ p₂ = q₁ ⟶ q₂ ↔ p₁ = q₁ ∧ p₂ = q₂ := by simp[Arrow.arrow]
 
-@[simp] lemma neg_inj (p q : Formula α) : ~p = ~q ↔ p = q := by simp [NegDefinition.neg]
+@[simp] lemma neg_inj (p q : Formula α) : ~p = ~q ↔ p = q := by simp [NegAbbrev.neg]
 
 def complexity : Formula α → ℕ
 | atom _  => 0
@@ -115,7 +115,7 @@ def degree : Formula α → Nat
 @[simp] lemma degree_box {p : Formula α} : degree (□p) = p.degree + 1 := rfl
 @[simp] lemma degree_and {p q : Formula α} : degree (p ⋏ q) = max p.degree q.degree := rfl
 @[simp] lemma degree_or {p q : Formula α} : degree (p ⋎ q) = max p.degree q.degree := rfl
-@[simp] lemma degree_not {p : Formula α} : degree (~p) = p.degree := by simp [NegDefinition.neg]
+@[simp] lemma degree_not {p : Formula α} : degree (~p) = p.degree := by simp [NegAbbrev.neg]
 
 @[elab_as_elim]
 def cases' {C : Formula α → Sort w}

--- a/Logic/Modal/Standard/HilbertStyle.lean
+++ b/Logic/Modal/Standard/HilbertStyle.lean
@@ -3,12 +3,12 @@ import Logic.Modal.Standard.System
 
 namespace LO.System
 
-variable {F : Type*} [StandardModalLogicalConnective F] [NegDefinition F] [DecidableEq F]
+variable {F : Type*} [StandardModalLogicalConnective F][DecidableEq F]
 variable {S : Type*} [System F S]
 variable {p q r : F} {Γ Δ : List F}
 
 variable {𝓢 : S}
-variable [Classical 𝓢]
+variable [System.Classical 𝓢] [System.NegationEquiv 𝓢]
 
 open FiniteContext
 

--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -146,7 +146,8 @@ lemma either_consistent (p) : (L)-Consistent (insert p T) ∨ (L)-Consistent (in
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_notParametricConsistent.mp hC.1;
   obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_notParametricConsistent.mp hC.2;
 
-  rw [←NegDefinition.neg] at hΓ₂ hΔ₂;
+  replace hΓ₂ := NegationEquiv.neg_equiv'!.mp hΓ₂;
+  replace hΔ₂ := NegationEquiv.neg_equiv'!.mp hΔ₂;
   have : L ⊢! Γ.conj' ⋏ Δ.conj' ⟶ ⊥ := demorgan₁'! $ disj₃'! (imp_trans! (implyOfNotOr'! $ demorgan₄'! hΓ₂) disj₁!) (imp_trans! (implyOfNotOr'! $ demorgan₄'! hΔ₂) disj₂!) lem!;
   have := @consisT (Γ ++ Δ) (by
     intro q hq;
@@ -380,7 +381,7 @@ lemma iff_congr : (Ω.theory *⊢[L]! (p ⟷ q)) → ((p ∈ Ω.theory) ↔ (q �
   . intro hp; exact iff_mem_imp.mp (membership_iff.mpr $ conj₁'! hpq) hp;
   . intro hq; exact iff_mem_imp.mp (membership_iff.mpr $ conj₂'! hpq) hq;
 
-lemma mem_dn_iff : (p ∈ Ω.theory) ↔ (~~p ∈ Ω.theory) := iff_congr $ (by simp)
+lemma mem_dn_iff : (p ∈ Ω.theory) ↔ (~~p ∈ Ω.theory) := iff_congr $ dn!
 
 lemma equality_def : Ω₁ = Ω₂ ↔ Ω₁.theory = Ω₂.theory := by
   constructor;

--- a/Logic/Modal/Standard/Kripke/ModalCompanion.lean
+++ b/Logic/Modal/Standard/Kripke/ModalCompanion.lean
@@ -46,7 +46,7 @@ variable {p q : Superintuitionistic.Formula α}
 @[simp] lemma and_def : (p ⋏ q)ᵍ = pᵍ ⋏ qᵍ := by simp [GoedelTranslation];
 @[simp] lemma or_def : (p ⋎ q)ᵍ = pᵍ ⋎ qᵍ := by simp [GoedelTranslation];
 @[simp] lemma imp_def : (p ⟶ q)ᵍ = □(pᵍ ⟶ qᵍ) := by simp [GoedelTranslation];
-@[simp] lemma neg_def' : (~p)ᵍ = □~(p)ᵍ := by simp [GoedelTranslation, NegDefinition.neg];
+@[simp] lemma neg_def' : (~p)ᵍ = □~(p)ᵍ := by simp [GoedelTranslation, NegAbbrev.neg];
 
 end GoedelTranslation
 

--- a/Logic/Propositional/Superintuitionistic/Formula.lean
+++ b/Logic/Propositional/Superintuitionistic/Formula.lean
@@ -24,8 +24,7 @@ instance : LogicalConnective (Formula α) where
   top := verum
   bot := falsum
 
-instance : NegDefinition (Formula α) where
-  neg := rfl
+instance : NegAbbrev (Formula α) := ⟨rfl⟩
 
 section ToString
 

--- a/Logic/Propositional/Superintuitionistic/Kripke/Classical.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Classical.lean
@@ -94,7 +94,7 @@ variable {V : ClassicalValuation α}
 @[simp] lemma and_def  : V ⊧ p ⋏ q ↔ V ⊧ p ∧ V ⊧ q := by simp
 @[simp] lemma or_def   : V ⊧ p ⋎ q ↔ V ⊧ p ∨ V ⊧ q := by simp
 @[simp] lemma imp_def  : V ⊧ p ⟶ q ↔ V ⊧ p → V ⊧ q := by simp; tauto;
-@[simp] lemma neg_def  : V ⊧ ~p ↔ ¬V ⊧ p := by simp only [NegDefinition.neg, imp_def, bot_def];
+@[simp] lemma neg_def  : V ⊧ ~p ↔ ¬V ⊧ p := by simp only [NegAbbrev.neg, imp_def, bot_def];
 
 end Formula.Kripke.ClassicalSatisfies
 

--- a/Logic/Propositional/Superintuitionistic/Kripke/Semantics.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Semantics.lean
@@ -110,7 +110,7 @@ local infix:45 " ⊩ " => Formula.Kripke.Satisfies M
 @[simp] lemma and_def  : w ⊩ p ⋏ q ↔ w ⊩ p ∧ w ⊩ q := by simp [Satisfies];
 @[simp] lemma or_def   : w ⊩ p ⋎ q ↔ w ⊩ p ∨ w ⊩ q := by simp [Satisfies];
 @[simp] lemma imp_def  : w ⊩ p ⟶ q ↔ ∀ {w'}, (w ≺ w') → (w' ⊩ p → w' ⊩ q) := by simp [Satisfies, imp_iff_not_or];
-@[simp] lemma neg_def  : w ⊩ ~p ↔ ∀ {w'}, (w ≺ w') → ¬(w' ⊩ p) := by simp [NegDefinition.neg];
+@[simp] lemma neg_def  : w ⊩ ~p ↔ ∀ {w'}, (w ≺ w') → ¬(w' ⊩ p) := by simp [NegAbbrev.neg];
 
 instance : Semantics.Top M.World where
   realize_top := by simp [Satisfies];


### PR DESCRIPTION
#69 に関連して，このプロジェクトで採用している1階述語論理の体系において`~p = (p ⟶ ⊥)`が成り立っているのか不明だった（おそらく違う？）ので，Supplementalの演繹を`𝓢`上で否定の同値性が言えれば良いという仮定に弱めた．　

```lean
protected class NegationEquiv (𝓢 : S) where
  neg_equiv {p} : 𝓢 ⊢ ~p ⟷ (p ⟶ ⊥)
```