### PR TITLE
ci: Fix cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: .lake
-          key: lake-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.ref }}
-          restore-keys: lake-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.ref }}
+          key: lake-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}
+          restore-keys: lake-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}
 
       - name: Fetching cache
         run: lake -R -Kenv=ci exe cache get


### PR DESCRIPTION
GitHubのキャッシュ仕様を考えるとPR駆動のとき`master`以外の別ブランチのキャッシュを取りに行くことは無いためこの識別は不要．また`master`とバージョンが違う場合はそのキャッシュを利用しないためこれでよいはず