### PR TITLE
fix(Modal): Remove Negation Abbreviation

### DIFF
--- a/Logic/FirstOrder/Incompleteness/DerivabilityCondition.lean
+++ b/Logic/FirstOrder/Incompleteness/DerivabilityCondition.lean
@@ -240,7 +240,7 @@ theorem unprovable_consistency [System.Consistent T] : T ⊬! Con⦍β⦎
   := unprovable_iff! iff_goedel_consistency |>.mp $ unprovable_goedel (T₀ := T₀)
 
 theorem unrefutable_consistency [System.Consistent T] [β.GoedelSound T₀ T] : T ⊬! ~Con⦍β⦎
-  := unprovable_iff! (neg_iff'! $ iff_goedel_consistency) |>.mp $ unrefutable_goedel (T₀ := T₀)
+  := unprovable_iff! (neg_replace_iff'! $ iff_goedel_consistency) |>.mp $ unrefutable_goedel (T₀ := T₀)
 
 end Second
 
@@ -304,7 +304,7 @@ lemma formalized_unrefutable_goedel [β.HilbertBernays T₀ T] [β.GoedelSound T
   : T ⊬! Con⦍β⦎ ⟶ ~⦍β⦎(~γ) := by
   by_contra hC;
   have : T ⊬! Con⦍β⦎ ⟶ ~⦍β⦎(~Con⦍β⦎)  := formalized_unprovable_not_consistency (T₀ := T₀);
-  have : T ⊢! Con⦍β⦎ ⟶ ~⦍β⦎(~Con⦍β⦎) := imp_trans''! hC $ Subtheory.prf! $ and₁'! $ neg_iff'! $ prov_distribute_iff (T₀ := T₀) $ neg_iff'! $ iff_goedel_consistency;
+  have : T ⊢! Con⦍β⦎ ⟶ ~⦍β⦎(~Con⦍β⦎) := imp_trans''! hC $ Subtheory.prf! $ and₁'! $ neg_replace_iff'! $ prov_distribute_iff (T₀ := T₀) $ neg_replace_iff'! $ iff_goedel_consistency;
   contradiction;
 
 end Loeb

--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -57,14 +57,14 @@ class HasAxiomDNE where
 
 protected class Minimal extends
               ModusPonens 𝓢,
-              HasAxiomVerum 𝓢,
+              HasAxiomVerum 𝓢, NegationEquiv 𝓢,
               HasAxiomImply₁ 𝓢, HasAxiomImply₂ 𝓢,
               HasAxiomAndElim₁ 𝓢, HasAxiomAndElim₂ 𝓢, HasAxiomAndInst 𝓢,
               HasAxiomOrInst₁ 𝓢, HasAxiomOrInst₂ 𝓢, HasAxiomOrElim 𝓢
 
 protected class Intuitionistic extends System.Minimal 𝓢, HasAxiomEFQ 𝓢
 
-protected class Classical extends System.Minimal 𝓢, NegationEquiv 𝓢, HasAxiomDNE 𝓢
+protected class Classical extends System.Minimal 𝓢, HasAxiomDNE 𝓢
 
 variable {𝓢}
 

--- a/Logic/Logic/HilbertStyle/Context.lean
+++ b/Logic/Logic/HilbertStyle/Context.lean
@@ -121,6 +121,7 @@ instance minimal (Γ : FiniteContext F 𝓢) : System.Minimal Γ where
   or₁ := fun _ _ ↦ of or₁
   or₂ := fun _ _ ↦ of or₂
   or₃ := fun _ _ _ ↦ of or₃
+  neg_equiv := fun _ ↦ of neg_equiv
 
 def mdp' (bΓ : Γ ⊢[𝓢] p ⟶ q) (bΔ : Δ ⊢[𝓢] p) : (Γ ++ Δ) ⊢[𝓢] q := wk (by simp) bΓ ⨀ wk (by simp) bΔ
 
@@ -157,8 +158,6 @@ instance : StrongCut (FiniteContext F 𝓢) (FiniteContext F 𝓢) :=
   ⟨fun {Γ Δ _} bΓ bΔ ↦
     have : Γ ⊢ Δ.conj := conjIntro' _ (fun _ hp ↦ bΓ hp)
     ofDef <| impTrans'' (toDef this) (toDef bΔ)⟩
-
-instance [System.NegationEquiv 𝓢] (Γ : FiniteContext F 𝓢) : System.NegationEquiv Γ := ⟨λ {_} => of neg_equiv⟩
 
 instance [HasAxiomEFQ 𝓢] (Γ : FiniteContext F 𝓢) : HasAxiomEFQ Γ := ⟨fun _ ↦ of efq⟩
 
@@ -303,8 +302,7 @@ instance minimal (Γ : Context F 𝓢) : System.Minimal Γ where
   or₁ := fun _ _ ↦ of or₁
   or₂ := fun _ _ ↦ of or₂
   or₃ := fun _ _ _ ↦ of or₃
-
-instance [System.NegationEquiv 𝓢] (Γ : Context F 𝓢) : System.NegationEquiv Γ := ⟨λ {_} => of neg_equiv⟩
+  neg_equiv := fun _ ↦ of neg_equiv
 
 instance [HasAxiomEFQ 𝓢] (Γ : Context F 𝓢) : HasAxiomEFQ Γ := ⟨fun _ ↦ of efq⟩
 

--- a/Logic/Logic/HilbertStyle/Supplemental.lean
+++ b/Logic/Logic/HilbertStyle/Supplemental.lean
@@ -29,6 +29,12 @@ lemma efq_of_neg! [System.NegationEquiv 𝓢] [HasAxiomEFQ 𝓢] (h : 𝓢 ⊢! 
   have dnp : [p] ⊢[𝓢]! p ⟶ ⊥ := of'! $ neg_equiv'!.mp h;
   exact efq'! (dnp ⨀ FiniteContext.id!);
 
+def neg_mdp [System.NegationEquiv 𝓢] (hnp : 𝓢 ⊢ ~p) (hn : 𝓢 ⊢ p) : 𝓢 ⊢ ⊥ := (neg_equiv'.mp hnp) ⨀ hn
+-- infixl:90 "⨀" => neg_mdp
+
+lemma neg_mdp! [System.NegationEquiv 𝓢] (hnp : 𝓢 ⊢! ~p) (hn : 𝓢 ⊢! p) : 𝓢 ⊢! ⊥ := ⟨neg_mdp hnp.some hn.some⟩
+-- infixl:90 "⨀" => neg_mdp!
+
 
 def orComm : 𝓢 ⊢ p ⋎ q ⟶ q ⋎ p := by
   apply deduct';
@@ -161,7 +167,6 @@ def contra₀ : 𝓢 ⊢ (p ⟶ q) ⟶ (~q ⟶ ~p) := by
 def contra₀' (b : 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ ~q ⟶ ~p := contra₀ ⨀ b
 lemma contra₀'! (b : 𝓢 ⊢! p ⟶ q) : 𝓢 ⊢! ~q ⟶ ~p := ⟨contra₀' b.some⟩
 
-
 def contra₀x2' (b : 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ ~~p ⟶ ~~q := contra₀' $ contra₀' b
 lemma contra₀x2'! (b : 𝓢 ⊢! p ⟶ q) : 𝓢 ⊢! ~~p ⟶ ~~q := ⟨contra₀x2' b.some⟩
 
@@ -190,9 +195,8 @@ def contra₃ [HasAxiomDNE 𝓢] : 𝓢 ⊢ (~p ⟶ ~q) ⟶ (q ⟶ p) :=  deduct
 @[simp] lemma contra₃! [HasAxiomDNE 𝓢] : 𝓢 ⊢! (~p ⟶ ~q) ⟶ (q ⟶ p) := ⟨contra₃⟩
 
 
-def negIff' (b : 𝓢 ⊢ p ⟷ q) : 𝓢 ⊢ ~p ⟷ ~q := iffIntro (contra₀' $ and₂' b) (contra₀' $ and₁' b)
-lemma neg_iff'! (b : 𝓢 ⊢! p ⟷ q) : 𝓢 ⊢! ~p ⟷ ~q := ⟨negIff' b.some⟩
-
+def negReplaceIff' (b : 𝓢 ⊢ p ⟷ q) : 𝓢 ⊢ ~p ⟷ ~q := iffIntro (contra₀' $ and₂' b) (contra₀' $ and₁' b)
+lemma neg_replace_iff'! (b : 𝓢 ⊢! p ⟷ q) : 𝓢 ⊢! ~p ⟷ ~q := ⟨negReplaceIff' b.some⟩
 
 section NegationEquiv
 

--- a/Logic/Modal/Standard/Boxdot.lean
+++ b/Logic/Modal/Standard/Boxdot.lean
@@ -8,6 +8,7 @@ def Formula.BoxdotTranslation : Formula α → Formula α
   | atom p => .atom p
   | ⊤ => ⊤
   | ⊥ => ⊥
+  | ~p => ~(BoxdotTranslation p)
   | p ⟶ q => (BoxdotTranslation p) ⟶ (BoxdotTranslation q)
   | p ⋏ q => (BoxdotTranslation p) ⋏ (BoxdotTranslation q)
   | p ⋎ q => (BoxdotTranslation p) ⋎ (BoxdotTranslation q)
@@ -37,12 +38,11 @@ lemma boxdotTranslatedK4_of_S4 (h : 𝐒𝟒 ⊢! p) : 𝐊𝟒 ⊢! pᵇ := by
 
 lemma iff_boxdotTranslation_S4 : 𝐒𝟒 ⊢! p ⟷ pᵇ := by
   induction p using Formula.rec' with
+  | hneg p ihp => dsimp [BoxdotTranslation]; exact neg_replace_iff'! ihp;
   | hand p q ihp ihq => dsimp [BoxdotTranslation]; exact and_replace_iff! ihp ihq;
   | hor p q ihp ihq => dsimp [BoxdotTranslation]; exact or_replace_iff! ihp ihq;
   | himp p q ihp ihq => dsimp [BoxdotTranslation]; exact imp_replace_iff! ihp ihq;
-  | hbox p ihp =>
-    dsimp [BoxdotTranslation];
-    exact iff_trans''! (box_iff! ihp) iff_box_boxdot!;
+  | hbox p ihp => dsimp [BoxdotTranslation]; exact iff_trans''! (box_iff! ihp) iff_box_boxdot!;
   | _ => dsimp [BoxdotTranslation]; exact iff_id!;
 
 lemma S4_of_boxdotTranslatedK4 (h : 𝐊𝟒 ⊢! pᵇ) : 𝐒𝟒 ⊢! p := by

--- a/Logic/Modal/Standard/ConsistentTheory.lean
+++ b/Logic/Modal/Standard/ConsistentTheory.lean
@@ -73,14 +73,15 @@ lemma provable_iff_insert_neg_not_Consistent : T *⊢[𝓓]! p ↔ ¬(𝓓)-Cons
     . exact hΓ₁;
     . apply and_imply_iff_imply_imply'!.mpr;
       apply imp_swap'!;
-      exact imp_trans''! hΓ₂ dni!;
+      exact neg_equiv'!.mp $ dni'! hΓ₂;
   . intro h;
     apply Context.provable_iff.mpr;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_Inconsistent.mp h;
     existsi Γ;
     constructor;
     . exact hΓ₁;
-    . exact imp_trans''! (imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂) dne!;
+    . have : Γ ⊢[𝓓]! ~p ⟶ ⊥ := imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
+      exact dne'! $ neg_equiv'!.mpr this;
 
 lemma unprovable_iff_insert_neg_Consistent : T *⊬[𝓓]! p ↔ (𝓓)-Consistent (insert (~p) T) := by
   constructor;
@@ -103,14 +104,15 @@ lemma neg_provable_iff_insert_not_Consistent : T *⊢[𝓓]! ~p ↔ ¬(𝓓)-Con
     . assumption;
     . apply and_imply_iff_imply_imply'!.mpr;
       apply imp_swap'!;
-      exact hΓ₂;
+      exact neg_equiv'!.mp hΓ₂;
   . intro h;
     apply Context.provable_iff.mpr;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_Inconsistent.mp h;
     existsi Γ;
     constructor;
     . exact hΓ₁;
-    . exact imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
+    . apply neg_equiv'!.mpr;
+      exact imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
 
 lemma neg_unprovable_iff_insert_Consistent : T *⊬[𝓓]! ~p ↔ (𝓓)-Consistent (insert (p) T) := by
   constructor;
@@ -122,7 +124,7 @@ variable (hConsis : (𝓓)-Consistent T)
 lemma unprovable_either : ¬(T *⊢[𝓓]! p ∧ T *⊢[𝓓]! ~p) := by
   by_contra hC;
   have ⟨hC₁, hC₂⟩ := hC;
-  have : T *⊢[𝓓]! ⊥ := hC₂ ⨀ hC₁;
+  have : T *⊢[𝓓]! ⊥ := neg_mdp! hC₂ hC₁;
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp this;
   have : 𝓓 ⊬! List.conj' Γ ⟶ ⊥ := hConsis hΓ₁;
   have : 𝓓 ⊢! List.conj' Γ ⟶ ⊥ := FiniteContext.toₛ! hΓ₂;
@@ -146,9 +148,9 @@ lemma either_consistent (p) : (𝓓)-Consistent (insert p T) ∨ (𝓓)-Consiste
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_Inconsistent.mp hC.1;
   obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_Inconsistent.mp hC.2;
 
-  replace hΓ₂ := neg_equiv'!.mp hΓ₂;
-  replace hΔ₂ := neg_equiv'!.mp hΔ₂;
-  have : 𝓓 ⊢! Γ.conj' ⋏ Δ.conj' ⟶ ⊥ := demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!;
+  replace hΓ₂ := neg_equiv'!.mpr hΓ₂;
+  replace hΔ₂ := neg_equiv'!.mpr hΔ₂;
+  have : 𝓓 ⊢! Γ.conj' ⋏ Δ.conj' ⟶ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
   have : 𝓓 ⊬! Γ.conj' ⋏ Δ.conj' ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj'! (hConsis (by
     simp;
     intro q hq;
@@ -261,7 +263,7 @@ lemma membership_iff : (p ∈ Ω.theory) ↔ (Ω.theory *⊢[𝓓]! p) := by
     suffices ~p ∉ Ω.theory by apply or_iff_not_imp_right.mp $ (either_mem Ω p); assumption;
     by_contra hC;
     have hnp : Ω.theory *⊢[𝓓]! ~p := Context.by_axm! hC;
-    have := hnp ⨀ hp;
+    have := neg_mdp! hnp hp;
     have := not_provable_falsum Ω.consistent;
     contradiction;
 
@@ -278,13 +280,14 @@ lemma subset_axiomset : Ax(𝓓) ⊆ Ω.theory := by
 @[simp]
 lemma unprovable_falsum : Ω.theory *⊬[𝓓]! ⊥ := by apply membership_iff.not.mp; simp
 
+@[simp]
 lemma iff_mem_neg : (~p ∈ Ω.theory) ↔ (p ∉ Ω.theory) := by
   constructor;
   . intro hnp;
     by_contra hp;
     replace hp := membership_iff.mp hp;
     replace hnp := membership_iff.mp hnp;
-    have : Ω.theory *⊢[𝓓]! ⊥ := hnp ⨀ hp;
+    have : Ω.theory *⊢[𝓓]! ⊥ := neg_mdp! hnp hp;
     have : Ω.theory *⊬[𝓓]! ⊥ := unprovable_falsum;
     contradiction;
   . intro hp;
@@ -339,7 +342,7 @@ lemma iff_mem_or : ((p ⋎ q) ∈ Ω.theory) ↔ (p ∈ Ω.theory) ∨ (q ∈ Ω
     have ⟨hp, hq⟩ := hC;
     replace hp := membership_iff.mp $ iff_mem_neg.mpr hp;
     replace hq := membership_iff.mp $ iff_mem_neg.mpr hq;
-    have : Ω.theory *⊢[𝓓]! ⊥ := or₃'''! hp hq hpq;
+    have : Ω.theory *⊢[𝓓]! ⊥ := or₃'''! (neg_equiv'!.mp hp) (neg_equiv'!.mp hq) hpq;
     have : Ω.theory *⊬[𝓓]! ⊥ := unprovable_falsum;
     contradiction;
   . rintro (hp | hq);

--- a/Logic/Modal/Standard/Deduction.lean
+++ b/Logic/Modal/Standard/Deduction.lean
@@ -52,6 +52,7 @@ inductive Deduction (𝓓 : DeductionParameter α) : (Formula α) → Type _
   | or₂ p q      : Deduction 𝓓 $ Axioms.OrInst₂ p q
   | or₃ p q r    : Deduction 𝓓 $ Axioms.OrElim p q r
   | dne p        : Deduction 𝓓 $ Axioms.DNE p
+  | neg_equiv p  : Deduction 𝓓 $ Axioms.NegEquiv p
 
 namespace Deduction
 
@@ -61,7 +62,7 @@ instance : System (Formula α) (DeductionParameter α) := ⟨Deduction⟩
 
 variable {𝓓 𝓓₁ 𝓓₂ : DeductionParameter α}
 
-instance : System.Minimal 𝓓 where
+instance : System.Classical 𝓓 where
   mdp := mdp
   verum := verum
   imply₁ := imply₁
@@ -72,9 +73,8 @@ instance : System.Minimal 𝓓 where
   or₁ := or₁
   or₂ := or₂
   or₃ := or₃
-
-instance : System.Classical 𝓓 where
   dne := dne
+  neg_equiv := neg_equiv
 
 lemma maxm! {p} (h : p ∈ 𝓓.axioms) : 𝓓 ⊢! p := ⟨maxm h⟩
 
@@ -137,7 +137,7 @@ noncomputable def inducition!
              motive p (hant hp)) → motive r.consequence ⟨rule hr (λ hp => (hant hp).some)⟩)
   (hMaxm     : ∀ {p}, (h : p ∈ Ax(𝓓)) → motive p ⟨maxm h⟩)
   (hMdp      : ∀ {p q}, {hpq : 𝓓 ⊢! p ⟶ q} → {hp : 𝓓 ⊢! p} → motive (p ⟶ q) hpq → motive p hp → motive q ⟨mdp hpq.some hp.some⟩)
-  (hVerum    : motive ⊤ ⟨verum⟩)
+  (hverum    : motive ⊤ ⟨verum⟩)
   (hImply₁   : ∀ {p q}, motive (p ⟶ q ⟶ p) $ ⟨imply₁ p q⟩)
   (hImply₂   : ∀ {p q r}, motive ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r) $ ⟨imply₂ p q r⟩)
   (hAndElim₁ : ∀ {p q}, motive (p ⋏ q ⟶ p) $ ⟨and₁ p q⟩)
@@ -147,6 +147,7 @@ noncomputable def inducition!
   (hOrInst₂  : ∀ {p q}, motive (q ⟶ p ⋎ q) $ ⟨or₂ p q⟩)
   (hOrElim   : ∀ {p q r}, motive ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r)) $ ⟨or₃ p q r⟩)
   (hDne      : ∀ {p}, motive (~~p ⟶ p) $ ⟨dne p⟩)
+  (hNegEquiv : ∀ {p}, motive (~p ⟷ (p ⟶ ⊥)) $ ⟨neg_equiv p⟩)
   : ∀ {p}, (d : 𝓓 ⊢! p) → motive p d := by
   intro p d;
   induction d.some with
@@ -161,7 +162,7 @@ noncomputable def inducition_with_necOnly! [𝓓.HasNecOnly]
   (hMaxm   : ∀ {p}, (h : p ∈ Ax(𝓓)) → motive p ⟨maxm h⟩)
   (hMdp    : ∀ {p q}, {hpq : 𝓓 ⊢! p ⟶ q} → {hp : 𝓓 ⊢! p} → motive (p ⟶ q) hpq → motive p hp → motive q (hpq ⨀ hp))
   (hNec    : ∀ {p}, {hp : 𝓓 ⊢! p} → (ihp : motive p hp) → motive (□p) (System.nec! hp))
-  (hVerum    : motive ⊤ ⟨verum⟩)
+  (hverum    : motive ⊤ ⟨verum⟩)
   (hImply₁   : ∀ {p q}, motive (p ⟶ q ⟶ p) $ ⟨imply₁ p q⟩)
   (hImply₂   : ∀ {p q r}, motive ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r) $ ⟨imply₂ p q r⟩)
   (hAndElim₁ : ∀ {p q}, motive (p ⋏ q ⟶ p) $ ⟨and₁ p q⟩)
@@ -171,6 +172,7 @@ noncomputable def inducition_with_necOnly! [𝓓.HasNecOnly]
   (hOrInst₂  : ∀ {p q}, motive (q ⟶ p ⋎ q) $ ⟨or₂ p q⟩)
   (hOrElim   : ∀ {p q r}, motive ((p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r)) $ ⟨or₃ p q r⟩)
   (hDne      : ∀ {p}, motive (~~p ⟶ p) $ ⟨dne p⟩)
+  (hNegEquiv : ∀ {p}, motive (~p ⟷ (p ⟶ ⊥)) $ ⟨neg_equiv p⟩)
   : ∀ {p}, (d : 𝓓 ⊢! p) → motive p d := by
   intro p d;
   induction d using Deduction.inducition! with
@@ -180,7 +182,7 @@ noncomputable def inducition_with_necOnly! [𝓓.HasNecOnly]
     rw [HasNecOnly.has_necessitation_only] at hrl;
     obtain ⟨p, e⟩ := hrl; subst e;
     exact @hNec p (hant (by simp)) $ ih (by simp);
-  | hVerum => exact hVerum
+  | hverum => exact hverum
   | hImply₁ => exact hImply₁
   | hImply₂ => exact hImply₂
   | hAndElim₁ => exact hAndElim₁
@@ -190,6 +192,7 @@ noncomputable def inducition_with_necOnly! [𝓓.HasNecOnly]
   | hOrInst₂ => exact hOrInst₂
   | hOrElim => exact hOrElim
   | hDne => exact hDne
+  | hNegEquiv => exact hNegEquiv
 
 end Deduction
 
@@ -354,6 +357,7 @@ macro_rules | `(tactic| trivial) => `(tactic|
     | apply or₁!
     | apply or₂!
     | apply or₃!
+    | apply neg_equiv!
   )
 
 macro_rules | `(tactic| trivial) => `(tactic | apply dne!)
@@ -436,8 +440,8 @@ lemma reducible_K4Loeb_K4Henkin : (𝐊𝟒(𝐋) : DeductionParameter α) ≤�
   | hMdp ihpq ihp => exact ihpq ⨀ ihp;
   | hRules rl hrl hant ihp =>
     rcases hrl with (hNec | hLoeb);
-    . obtain ⟨p, e⟩ := hNec; subst_vars; exact nec! $ ihp (by aesop);
-    . obtain ⟨p, e⟩ := hLoeb; subst_vars; exact loeb! $ ihp (by aesop);
+    . obtain ⟨p, e⟩ := hNec; subst_vars; exact nec! $ ihp $ by simp_all only [List.mem_singleton, forall_eq];
+    . obtain ⟨p, e⟩ := hLoeb; subst_vars; exact loeb! $ ihp $ by simp_all only [List.mem_singleton, forall_eq];
   | _ => trivial;
 
 lemma reducible_K4Henkin_K4H : (𝐊𝟒(𝐇) : DeductionParameter α) ≤ₛ 𝐊𝟒𝐇 := by
@@ -451,8 +455,8 @@ lemma reducible_K4Henkin_K4H : (𝐊𝟒(𝐇) : DeductionParameter α) ≤ₛ �
   | hMdp ihpq ihp => exact ihpq ⨀ ihp;
   | hRules rl hrl hant ihp =>
     rcases hrl with (hNec | hHenkin);
-    . obtain ⟨p, e⟩ := hNec; subst_vars; exact nec! $ ihp (by aesop);
-    . obtain ⟨p, e⟩ := hHenkin; subst_vars; exact henkin! $ ihp (by aesop);
+    . obtain ⟨p, e⟩ := hNec; subst_vars; exact nec! $ ihp $ by simp_all only [List.mem_singleton, forall_eq];
+    . obtain ⟨p, e⟩ := hHenkin; subst_vars; exact henkin! $ ihp $ by simp_all only [List.mem_singleton, forall_eq];
   | _ => trivial;
 
 lemma reducible_K4Henkin_GL : (𝐊𝟒𝐇 : DeductionParameter α) ≤ₛ 𝐆𝐋 := by

--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -51,21 +51,22 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
 
         have hΔconj : (◇'⁻¹^[n]Δ).conj' ∈ Ω₂.theory := iff_mem_conj'.mpr hΔ₂;
 
-        have := and_imply_iff_imply_imply'!.mp hC;
-
-        have : 𝝂Ax ⊢! Γ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := sorry
-          /-
-          imp_trans''! (and_imply_iff_imply_imply'!.mp hC)
-          $ contra₂'! $ imp_trans''! (and₂'! multidia_duality!)
-          $ imp_trans''! iff_conj'multidia_multidiaconj'! $ by
+        have : (◇'⁻¹^[n]Δ).conj' ∉ Ω₂.theory := by {
+          have d₁ : 𝝂Ax ⊢! Γ.conj' ⟶ Δ.conj' ⟶ ⊥ := and_imply_iff_imply_imply'!.mp hC;
+          have : 𝝂Ax ⊢! (◇'^[n]◇'⁻¹^[n]Δ).conj' ⟶ Δ.conj' := by
             apply conj'conj'_subset;
             intro q hq;
-            obtain ⟨r, _, _⟩ := by simpa using hΔ q hq;
+            obtain ⟨r, _, _⟩ := hΔ q hq;
             subst_vars;
             simpa;
-          -/
-        have : (𝝂Ax) ⊢! □Γ.conj' ⟶ □^[(n + 1)](~(◇'⁻¹^[n]Δ).conj') := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
-        have : (◇'⁻¹^[n]Δ).conj' ∉ Ω₂.theory := iff_mem_neg.mp $ h $ membership_iff.mpr $ (Context.of! this) ⨀ dΓconj;
+          have : 𝝂Ax ⊢! ◇^[n](◇'⁻¹^[n]Δ).conj' ⟶ Δ.conj' := imp_trans''! iff_conj'multidia_multidiaconj'! $ this;
+          have : 𝝂Ax ⊢! ~(□^[n](~(◇'⁻¹^[n]Δ).conj')) ⟶ Δ.conj' := imp_trans''! (and₂'! multidia_duality!) this;
+          have : 𝝂Ax ⊢! ~Δ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := contra₂'! this;
+          have : 𝝂Ax ⊢! (Δ.conj' ⟶ ⊥) ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := imp_trans''! (and₂'! neg_equiv!) this;
+          have : 𝝂Ax ⊢! Γ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := imp_trans''! d₁ this;
+          have : 𝝂Ax ⊢! □Γ.conj' ⟶ □^[(n + 1)](~(◇'⁻¹^[n]Δ).conj') := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
+          exact iff_mem_neg.mp $ h $ membership_iff.mpr $ (Context.of! this) ⨀ dΓconj;
+        }
 
         contradiction;
       use Ω;

--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -51,7 +51,11 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
 
         have hΔconj : (◇'⁻¹^[n]Δ).conj' ∈ Ω₂.theory := iff_mem_conj'.mpr hΔ₂;
 
-        have : (𝝂Ax) ⊢! Γ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := imp_trans''! (and_imply_iff_imply_imply'!.mp hC)
+        have := and_imply_iff_imply_imply'!.mp hC;
+
+        have : 𝝂Ax ⊢! Γ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := sorry
+          /-
+          imp_trans''! (and_imply_iff_imply_imply'!.mp hC)
           $ contra₂'! $ imp_trans''! (and₂'! multidia_duality!)
           $ imp_trans''! iff_conj'multidia_multidiaconj'! $ by
             apply conj'conj'_subset;
@@ -59,6 +63,7 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
             obtain ⟨r, _, _⟩ := by simpa using hΔ q hq;
             subst_vars;
             simpa;
+          -/
         have : (𝝂Ax) ⊢! □Γ.conj' ⟶ □^[(n + 1)](~(◇'⁻¹^[n]Δ).conj') := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
         have : (◇'⁻¹^[n]Δ).conj' ∉ Ω₂.theory := iff_mem_neg.mp $ h $ membership_iff.mpr $ (Context.of! this) ⨀ dΓconj;
 
@@ -128,7 +133,7 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Ax) ⊧ p ↔ ((�
     have : (𝝂Ax)-Consistent ({~p}) := by
       intro Γ hΓ;
       by_contra hC;
-      have : _ ⊢! p := dne'! $ replace_imply_left_conj'! hΓ hC;
+      have : 𝝂Ax ⊢! p := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj'! hΓ hC;
       contradiction;
     obtain ⟨Ω, hΩ⟩ := lindenbaum this;
     simp [Kripke.ValidOnModel];

--- a/Logic/Modal/Standard/Kripke/Filteration.lean
+++ b/Logic/Modal/Standard/Kripke/Filteration.lean
@@ -25,7 +25,6 @@ section
 
 def filterEquiv (M : Kripke.Model α) (T : Theory α) [SubformulaClosed T] (x y : M.World) := ∀ p ∈ T, x ⊧ p ↔ y ⊧ p
 
--- TODO: Model universe specifying is not needed: should be `Model.{u, v}`.
 variable (M : Kripke.Model α) (T : Theory α) [T_closed : SubformulaClosed T]
 
 lemma filterEquiv.equivalence : Equivalence (filterEquiv M T) where
@@ -136,6 +135,14 @@ theorem filteration {x : M.World} {p : Formula α} (hs : p ∈ T) : x ⊧ p ↔ 
   | hatom a =>
     have := FM.def_valuation (cast FM.def_world.symm ⟦x⟧) a hs;
     simp_all [Satisfies];
+  | hneg p ihp =>
+    constructor;
+    . have sp := T_closed.neg hs;
+      rintro hpx;
+      exact ihp sp |>.not.mp hpx;
+    . have sp := T_closed.neg hs;
+      rintro hpx;
+      exact ihp sp |>.not.mpr hpx;
   | hand p q ihp ihq =>
     constructor;
     . have ⟨sp, sq⟩ := T_closed.and hs

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -258,9 +258,12 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
 
     have : (𝝂Ax) ⊢! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by
       apply and_imply_iff_imply_imply'!.mpr;
+      sorry;
+      /-
       exact imp_trans''!
         (show (𝝂Ax) ⊢! □^[t.n](Δ.conj') ⟶ □^[t.n](~Γ.conj') by exact imply_multibox_distribute'! $ contra₁'! $ and_imply_iff_imply_imply'!.mp hC)
         (show (𝝂Ax) ⊢! □^[t.n](~Γ.conj') ⟶ ~(◇^[t.n]Γ.conj') by exact contra₁'! $ and₁'! $ multidia_duality!);
+      -/
     have : (𝝂Ax) ⊬! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by simpa using Ω₃.consistent (Γ := [□^[t.n](Δ.conj'), ◇^[t.n](Γ.conj')]) (by simp_all)
 
     contradiction;

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -256,15 +256,13 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
       (multiframe_def_multidia.mp r₁₂ hΓconj)
     have : ◇^[t.n]Γ.conj' ∈ Ω₃.theory := multiframe_def_multibox.mp r₁₃ this;
 
-    have : (𝝂Ax) ⊢! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by
+    have : 𝝂Ax ⊢! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by {
       apply and_imply_iff_imply_imply'!.mpr;
-      sorry;
-      /-
       exact imp_trans''!
-        (show (𝝂Ax) ⊢! □^[t.n](Δ.conj') ⟶ □^[t.n](~Γ.conj') by exact imply_multibox_distribute'! $ contra₁'! $ and_imply_iff_imply_imply'!.mp hC)
-        (show (𝝂Ax) ⊢! □^[t.n](~Γ.conj') ⟶ ~(◇^[t.n]Γ.conj') by exact contra₁'! $ and₁'! $ multidia_duality!);
-      -/
-    have : (𝝂Ax) ⊬! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by simpa using Ω₃.consistent (Γ := [□^[t.n](Δ.conj'), ◇^[t.n](Γ.conj')]) (by simp_all)
+        (show 𝝂Ax ⊢! □^[t.n](Δ.conj') ⟶ □^[t.n](~Γ.conj') by exact imply_multibox_distribute'! $ contra₁'! $ imp_trans''! (and_imply_iff_imply_imply'!.mp hC) (and₂'! neg_equiv!))
+        (show 𝝂Ax ⊢! □^[t.n](~Γ.conj') ⟶ (◇^[t.n]Γ.conj') ⟶ ⊥ by exact imp_trans''! (contra₁'! $ and₁'! $ multidia_duality!) (and₁'! neg_equiv!));
+    }
+    have : 𝝂Ax ⊬! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by simpa using Ω₃.consistent (Γ := [□^[t.n](Δ.conj'), ◇^[t.n](Γ.conj')]) (by simp_all)
 
     contradiction;
 

--- a/Logic/Modal/Standard/Kripke/ModalCompanion.lean
+++ b/Logic/Modal/Standard/Kripke/ModalCompanion.lean
@@ -23,12 +23,12 @@ variable [DecidableEq α] [Inhabited α] [Encodable α]
 /-- Gödel Translation -/
 def GoedelTranslation : Superintuitionistic.Formula α → Formula α
   | .atom a  => □(Formula.atom a)
-  | .verum   => ⊤
-  | .falsum  => ⊥
-  | .and p q => (GoedelTranslation p) ⋏ (GoedelTranslation q)
-  | .or p q  => (GoedelTranslation p) ⋎ (GoedelTranslation q)
-  | .neg p   => □~(GoedelTranslation p)
-  | .imp p q => □((GoedelTranslation p) ⟶ (GoedelTranslation q))
+  | ⊤ => ⊤
+  | ⊥ => ⊥
+  | p ⋏ q => (GoedelTranslation p) ⋏ (GoedelTranslation q)
+  | p ⋎ q  => (GoedelTranslation p) ⋎ (GoedelTranslation q)
+  | ~p   => □~(GoedelTranslation p)
+  | p ⟶ q => □((GoedelTranslation p) ⟶ (GoedelTranslation q))
 
 postfix:75 "ᵍ" => GoedelTranslation
 
@@ -41,17 +41,15 @@ variable {p q r : Superintuitionistic.Formula α}
 
 lemma axiomTc_GTranslate! [System.K4 m𝓓] : m𝓓 ⊢! pᵍ ⟶ □pᵍ := by
   induction p using Superintuitionistic.Formula.rec' with
-  | hatom => simp [GoedelTranslation, axiomFour!];
-  | himp => simp [GoedelTranslation, axiomFour!];
-  | hfalsum => simp [GoedelTranslation, efq!];
   | hverum => exact dhyp! (nec! verum!);
-  | hneg p => simp [GoedelTranslation];
+  | hfalsum => simp only [GoedelTranslation, efq!];
   | hand p q ihp ihq =>
     simp only [GoedelTranslation];
     exact imp_trans''! (and_replace! ihp ihq) collect_box_and!
   | hor p q ihp ihq =>
     simp only [GoedelTranslation];
     exact imp_trans''! (or₃''! (imply_or_left'! ihp) (imply_or_right'! ihq)) collect_box_or!
+  | _ => simp only [GoedelTranslation, axiomFour!];
 
 instance [System.S4 m𝓓] : System.K4 m𝓓 where
 

--- a/Logic/Modal/Standard/Kripke/ModalCompanion.lean
+++ b/Logic/Modal/Standard/Kripke/ModalCompanion.lean
@@ -27,6 +27,7 @@ def GoedelTranslation : Superintuitionistic.Formula α → Formula α
   | .falsum  => ⊥
   | .and p q => (GoedelTranslation p) ⋏ (GoedelTranslation q)
   | .or p q  => (GoedelTranslation p) ⋎ (GoedelTranslation q)
+  | .neg p   => □~(GoedelTranslation p)
   | .imp p q => □((GoedelTranslation p) ⟶ (GoedelTranslation q))
 
 postfix:75 "ᵍ" => GoedelTranslation
@@ -44,6 +45,7 @@ lemma axiomTc_GTranslate! [System.K4 m𝓓] : m𝓓 ⊢! pᵍ ⟶ □pᵍ := by
   | himp => simp [GoedelTranslation, axiomFour!];
   | hfalsum => simp [GoedelTranslation, efq!];
   | hverum => exact dhyp! (nec! verum!);
+  | hneg p => simp [GoedelTranslation];
   | hand p q ihp ihq =>
     simp only [GoedelTranslation];
     exact imp_trans''! (and_replace! ihp ihq) collect_box_and!
@@ -59,12 +61,12 @@ private lemma provable_efq_of_provable_S4.case_imply₁ [System.K4 m𝓓] : m�
 
 private lemma provable_efq_of_provable_S4.case_imply₂ [System.S4 m𝓓] : m𝓓 ⊢! ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ p ⟶ r)ᵍ := by
   simp only [GoedelTranslation];
-  refine nec! $ imp_trans''! (imp_trans''! (axiomK'! $ nec! ?b) axiomFour!) $ axiomK'! $ nec! $ imp_trans''! (axiomK'! $ nec! imply₂!) axiomK!;
+  apply nec! $ imp_trans''! (imp_trans''! (axiomK'! $ nec! ?b) axiomFour!) $ axiomK'! $ nec! $ imp_trans''! (axiomK'! $ nec! imply₂!) axiomK!;
   apply provable_iff_provable.mpr;
   apply deduct_iff.mpr;
   apply deduct_iff.mpr;
-  have : [pᵍ, pᵍ ⟶ □(qᵍ ⟶ rᵍ)] ⊢[m𝓓]! pᵍ := by_axm! (by simp);
-  have : [pᵍ, pᵍ ⟶ □(qᵍ ⟶ rᵍ)] ⊢[m𝓓]! (pᵍ ⟶ □(qᵍ ⟶ rᵍ)) := by_axm! (by simp);
+  have : [pᵍ, pᵍ ⟶ □(qᵍ ⟶ rᵍ)] ⊢[m𝓓]! pᵍ := by_axm!;
+  have : [pᵍ, pᵍ ⟶ □(qᵍ ⟶ rᵍ)] ⊢[m𝓓]! (pᵍ ⟶ □(qᵍ ⟶ rᵍ)) := by_axm!;
   have : [pᵍ, pᵍ ⟶ □(qᵍ ⟶ rᵍ)] ⊢[m𝓓]! □(qᵍ ⟶ rᵍ) := (by assumption) ⨀ (by assumption);
   exact axiomT'! this;
 
@@ -76,6 +78,12 @@ private lemma provable_efq_of_provable_S4.case_or₃ [System.K4 m𝓓] : m𝓓 �
   simp only [GoedelTranslation];
   exact nec! $ imp_trans''! axiomFour! $ axiomK'! $ nec! $ imp_trans''! (axiomK'! $ nec! $ or₃!) axiomK!;
 
+private lemma provable_efq_of_provable_S4.case_neg_equiv [System.K4 m𝓓] : m𝓓 ⊢! (Axioms.NegEquiv p)ᵍ := by
+  simp only [GoedelTranslation];
+  apply and₃'!;
+  . exact nec! $ axiomK'! $ nec! $ and₁'! neg_equiv!;
+  . exact nec! $ axiomK'! $ nec! $ and₂'! neg_equiv!;
+
 open provable_efq_of_provable_S4 in
 lemma provable_efq_of_provable_S4 (h : 𝐈𝐧𝐭 ⊢! p) : 𝐒𝟒 ⊢! pᵍ := by
   induction h.some with
@@ -85,15 +93,16 @@ lemma provable_efq_of_provable_S4 (h : 𝐈𝐧𝐭 ⊢! p) : 𝐒𝟒 ⊢! pᵍ
     exact nec! efq!;
   | mdp hpq hp ihpq ihp =>
     exact axiomT'! $ axiomK''! (by simpa using ihpq ⟨hpq⟩) $ nec! $ ihp ⟨hp⟩;
+  | and₁ => simp only [GoedelTranslation]; exact nec! and₁!;
+  | and₂ => simp only [GoedelTranslation]; exact nec! and₂!;
+  | or₁ => simp only [GoedelTranslation]; exact nec! or₁!;
+  | or₂ => simp only [GoedelTranslation]; exact nec! or₂!;
   | verum => apply verum!;
   | imply₁ => exact case_imply₁;
   | imply₂ => exact case_imply₂;
-  | and₁ => simp only [GoedelTranslation]; exact nec! and₁!;
-  | and₂ => simp only [GoedelTranslation]; exact nec! and₂!;
   | and₃ => exact case_and₃;
-  | or₁ => simp only [GoedelTranslation]; exact nec! or₁!;
-  | or₂ => simp only [GoedelTranslation]; exact nec! or₂!;
   | or₃ => exact case_or₃;
+  | neg_equiv => exact case_neg_equiv;
 
 open Superintuitionistic.Kripke
 open Superintuitionistic.Formula.Kripke

--- a/Logic/Modal/Standard/Kripke/Preservation.lean
+++ b/Logic/Modal/Standard/Kripke/Preservation.lean
@@ -65,6 +65,14 @@ lemma modal_equivalent_of_bisimilar (bisx : Bi x₁ x₂) : (M₁, x₁) ↭ (M�
       exact ihq bisx |>.mp $ hpq $ ihp bisx |>.mpr hp;
     . intro hpq hp;
       exact ihq bisx |>.mpr $ hpq $ ihp bisx |>.mp hp;
+  | hneg p ih =>
+    constructor;
+    . intro hnp hp;
+      have := ih bisx |>.not.mp hnp;
+      contradiction;
+    . intro hnp hp;
+      have := ih bisx |>.not.mpr hnp;
+      contradiction;
   | _ => simp_all;
 
 end ModalEquivalent

--- a/Logic/Modal/Standard/Kripke/Semantics.lean
+++ b/Logic/Modal/Standard/Kripke/Semantics.lean
@@ -134,6 +134,7 @@ def Formula.Kripke.Satisfies (M : Kripke.Model α) (x : M.World) : Formula α �
   | and p q => (Satisfies M x p) ∧ (Satisfies M x q)
   | or p q  => (Satisfies M x p) ∨ (Satisfies M x q)
   | imp p q => (Satisfies M x p) → (Satisfies M x q)
+  | neg p   => ¬(Satisfies M x p)
   | box p   => ∀ {y}, x ≺ y → (Satisfies M y p)
 
 namespace Formula.Kripke.Satisfies

--- a/Logic/Modal/Standard/Maximal.lean
+++ b/Logic/Modal/Standard/Maximal.lean
@@ -13,8 +13,8 @@ def Formula.toModalFormula : Formula α → Modal.Standard.Formula α
   | .atom a => Modal.Standard.Formula.atom a
   | ⊤ => ⊤
   | ⊥ => ⊥
-  | p ⟶ q => (toModalFormula p) ⟶ (toModalFormula q)
   | ~p => ~(toModalFormula p)
+  | p ⟶ q => (toModalFormula p) ⟶ (toModalFormula q)
   | p ⋏ q => (toModalFormula p) ⋏ (toModalFormula q)
   | p ⋎ q => (toModalFormula p) ⋎ (toModalFormula q)
 postfix:75 "ᴹ" => Formula.toModalFormula
@@ -124,7 +124,7 @@ lemma of_classical {m𝓓 : Modal.Standard.DeductionParameter α} {p : Superintu
     simp_all;
     rcases ih with (efq | lem);
     . obtain ⟨q, e⟩ := efq; subst_vars; exact efq!;
-    . obtain ⟨q, e⟩ := lem; subst_vars; sorry; -- exact lem!;
+    . obtain ⟨q, e⟩ := lem; subst_vars; exact lem!;
   | mdp h₁ h₂ ih₁ ih₂ =>
     dsimp only [Superintuitionistic.Formula.toModalFormula] at ih₁ ih₂;
     exact (ih₁ ⟨h₁⟩) ⨀ (ih₂ ⟨h₂⟩);

--- a/Logic/Modal/Standard/Maximal.lean
+++ b/Logic/Modal/Standard/Maximal.lean
@@ -34,6 +34,7 @@ def toPropFormula (p : Formula α) (_ : p.degree = 0 := by simp_all) : Superintu
   | atom a => Superintuitionistic.Formula.atom a
   | ⊤ => ⊤
   | ⊥ => ⊥
+  | ~p => ~(p.toPropFormula)
   | p ⋏ q => p.toPropFormula ⋏ q.toPropFormula
   | p ⋎ q => p.toPropFormula ⋎ q.toPropFormula
   | p ⟶ q => p.toPropFormula ⟶ q.toPropFormula
@@ -45,6 +46,7 @@ def TrivTranslation : Formula α → Formula α
   | box p => p.TrivTranslation
   | ⊤ => ⊤
   | ⊥ => ⊥
+  | ~p => ~(p.TrivTranslation)
   | p ⟶ q => (p.TrivTranslation) ⟶ (q.TrivTranslation)
   | p ⋏ q => (p.TrivTranslation) ⋏ (q.TrivTranslation)
   | p ⋎ q => (p.TrivTranslation) ⋎ (q.TrivTranslation)
@@ -53,7 +55,7 @@ postfix:75 "ᵀ" => TrivTranslation
 namespace TrivTranslation
 
 @[simp] lemma degree_zero : pᵀ.degree = 0 := by induction p <;> simp [TrivTranslation, degree, *];
-@[simp] lemma back : pᵀᴾᴹ = pᵀ := by induction p using rec' <;> simp [Superintuitionistic.Formula.toModalFormula, TrivTranslation, *];
+@[simp] lemma back : pᵀᴾᴹ = pᵀ := by sorry; -- induction p using rec' <;> simp [Superintuitionistic.Formula.toModalFormula, TrivTranslation, *];
 
 end TrivTranslation
 
@@ -63,6 +65,7 @@ def VerTranslation : Formula α → Formula α
   | box _ => ⊤
   | ⊤ => ⊤
   | ⊥ => ⊥
+  | ~p => ~(p.VerTranslation)
   | p ⟶ q => (p.VerTranslation) ⟶ (q.VerTranslation)
   | p ⋏ q => (p.VerTranslation) ⋏ (q.VerTranslation)
   | p ⋎ q => (p.VerTranslation) ⋎ (q.VerTranslation)
@@ -74,7 +77,7 @@ namespace VerTranslation
 @[simp] lemma back  : pⱽᴾᴹ = pⱽ := by
   induction p using rec' with
   | hbox _ => simp [VerTranslation, toPropFormula, Superintuitionistic.Formula.toModalFormula];
-  | _ => simp [VerTranslation, toPropFormula, Superintuitionistic.Formula.toModalFormula, *];
+  | _ => sorry; -- simp [VerTranslation, toPropFormula, Superintuitionistic.Formula.toModalFormula, *];
 
 end VerTranslation
 
@@ -89,13 +92,13 @@ open System
 open Formula
 
 lemma deducible_iff_trivTranslation : 𝐓𝐫𝐢𝐯 ⊢! p ⟷ pᵀ := by
-  -- have := @Deduction.ofTriv;
   induction p using Formula.rec' with
   | hbox p ih =>
     simp [TrivTranslation];
     apply iff_intro!;
     . exact imp_trans''! axiomT! (and₁'! ih)
     . exact imp_trans''! (and₂'! ih) axiomTc!
+  | hneg _ ih => exact neg_replace_iff'! ih;
   | himp _ _ ih₁ ih₂ => exact imp_replace_iff! ih₁ ih₂;
   | hand _ _ ih₁ ih₂ => exact and_replace_iff! ih₁ ih₂;
   | hor _ _ ih₁ ih₂ => exact or_replace_iff! ih₁ ih₂;
@@ -107,6 +110,7 @@ lemma deducible_iff_verTranslation : 𝐕𝐞𝐫 ⊢! p ⟷ pⱽ := by
     apply iff_intro!;
     . exact imply₁'! verum!
     . exact dhyp! (by simp)
+  | hneg _ ih => exact neg_replace_iff'! ih;
   | himp _ _ ih₁ ih₂ => exact imp_replace_iff! ih₁ ih₂;
   | hand _ _ ih₁ ih₂ => exact and_replace_iff! ih₁ ih₂;
   | hor _ _ ih₁ ih₂ => exact or_replace_iff! ih₁ ih₂;
@@ -119,7 +123,7 @@ lemma of_classical {m𝓓 : Modal.Standard.DeductionParameter α} {p : Superintu
     simp_all;
     rcases ih with (efq | lem);
     . obtain ⟨q, e⟩ := efq; subst_vars; exact efq!;
-    . obtain ⟨q, e⟩ := lem; subst_vars; exact lem!;
+    . obtain ⟨q, e⟩ := lem; subst_vars; sorry; -- exact lem!;
   | mdp h₁ h₂ ih₁ ih₂ =>
     dsimp only [Superintuitionistic.Formula.toModalFormula] at ih₁ ih₂;
     exact (ih₁ ⟨h₁⟩) ⨀ (ih₂ ⟨h₂⟩);

--- a/Logic/Modal/Standard/Maximal.lean
+++ b/Logic/Modal/Standard/Maximal.lean
@@ -14,6 +14,7 @@ def Formula.toModalFormula : Formula α → Modal.Standard.Formula α
   | ⊤ => ⊤
   | ⊥ => ⊥
   | p ⟶ q => (toModalFormula p) ⟶ (toModalFormula q)
+  | ~p => ~(toModalFormula p)
   | p ⋏ q => (toModalFormula p) ⋏ (toModalFormula q)
   | p ⋎ q => (toModalFormula p) ⋎ (toModalFormula q)
 postfix:75 "ᴹ" => Formula.toModalFormula
@@ -55,7 +56,7 @@ postfix:75 "ᵀ" => TrivTranslation
 namespace TrivTranslation
 
 @[simp] lemma degree_zero : pᵀ.degree = 0 := by induction p <;> simp [TrivTranslation, degree, *];
-@[simp] lemma back : pᵀᴾᴹ = pᵀ := by sorry; -- induction p using rec' <;> simp [Superintuitionistic.Formula.toModalFormula, TrivTranslation, *];
+@[simp] lemma back : pᵀᴾᴹ = pᵀ := by induction p using rec' <;> simp [Superintuitionistic.Formula.toModalFormula, TrivTranslation, *];
 
 end TrivTranslation
 
@@ -77,7 +78,7 @@ namespace VerTranslation
 @[simp] lemma back  : pⱽᴾᴹ = pⱽ := by
   induction p using rec' with
   | hbox _ => simp [VerTranslation, toPropFormula, Superintuitionistic.Formula.toModalFormula];
-  | _ => sorry; -- simp [VerTranslation, toPropFormula, Superintuitionistic.Formula.toModalFormula, *];
+  | _ => simp [VerTranslation, toPropFormula, Superintuitionistic.Formula.toModalFormula, *];
 
 end VerTranslation
 

--- a/Logic/Modal/Standard/PLoN/Semantics.lean
+++ b/Logic/Modal/Standard/PLoN/Semantics.lean
@@ -54,6 +54,7 @@ def Formula.PLoN.Satisfies (M : PLoN.Model α) (w : M.World) : Formula α → Pr
   | atom a  => M.Valuation w a
   | verum   => True
   | falsum  => False
+  | neg p   => ¬(PLoN.Satisfies M w p)
   | and p q => (PLoN.Satisfies M w p) ∧ (PLoN.Satisfies M w q)
   | or p q  => (PLoN.Satisfies M w p) ∨ (PLoN.Satisfies M w q)
   | imp p q => (PLoN.Satisfies M w p) → (PLoN.Satisfies M w q)

--- a/Logic/Modal/Standard/Provability/Basic.lean
+++ b/Logic/Modal/Standard/Provability/Basic.lean
@@ -21,6 +21,7 @@ def interpretation
   | p ⟶ q => (interpretation f β p) ⟶ (interpretation f β q)
   | p ⋏ q => (interpretation f β p) ⋏ (interpretation f β q)
   | p ⋎ q => (interpretation f β p) ⋎ (interpretation f β q)
+  | ~p => ~(interpretation f β p)
 scoped notation f "[" β "] " p => interpretation f β p -- TODO: more good notation
 
 /-
@@ -72,10 +73,10 @@ lemma arithmetical_soundness_K4Loeb [β.HilbertBernays T₀ T] (h : 𝐊𝟒(�
   | hRules rl hrl hant ih =>
     rcases hrl with (hNec | hLoeb)
     . obtain ⟨p, e⟩ := hNec; subst e;
-      simp_all;
+      simp_all only [List.mem_singleton, forall_eq];
       exact D1s (T₀ := T₀) ih;
     . obtain ⟨p, e⟩ := hLoeb; subst e;
-      simp_all;
+      simp_all only [List.mem_singleton, forall_eq]
       exact Loeb.LT T₀ ih;
   | hMaxm hp =>
     rcases hp with (hK | hFour)
@@ -86,7 +87,7 @@ lemma arithmetical_soundness_K4Loeb [β.HilbertBernays T₀ T] (h : 𝐊𝟒(�
     exact ihpq ⨀ ihp;
   | hDne =>
     dsimp [interpretation];
-    exact imp_trans''! (and₁'! $ iff_comm'! negneg_equiv!) dne!;
+    exact dne!;
   | _ => dsimp [interpretation]; trivial;
 
 theorem arithmetical_soundness_GL [β.HilbertBernays T₀ T] (h : 𝐆𝐋 ⊢! p) : ∀ {f : realization L α}, T ⊢! (f[β] p) := by
@@ -99,15 +100,15 @@ lemma arithmetical_soundness_N [β.HilbertBernays₁ T₀ T] (h : 𝐍 ⊢! p) :
   induction h using Deduction.inducition! with
   | hMaxm hp => simp at hp;
   | hRules rl hrl hant ih =>
-    simp at hrl;
+    simp only [Set.mem_setOf_eq] at hrl;
     obtain ⟨p, e⟩ := hrl; subst e; simp_all;
     exact D1s (T₀ := T₀) ih;
   | hMdp ihpq ihp =>
-    simp [interpretation] at ihpq;
+    simp only [interpretation] at ihpq;
     exact ihpq ⨀ ihp;
   | hDne =>
     dsimp [interpretation];
-    exact imp_trans''! (and₁'! $ iff_comm'! negneg_equiv!) dne!;
+    exact dne!;
   | _ => dsimp [interpretation]; trivial;
 
 end ArithmeticalSoundness

--- a/Logic/Modal/Standard/System.lean
+++ b/Logic/Modal/Standard/System.lean
@@ -160,9 +160,9 @@ def multiboxIff' (h : 𝓢 ⊢ p ⟷ q) : 𝓢 ⊢ □^[n]p ⟷ □^[n]q := by
 
 def diaIff' (h : 𝓢 ⊢ p ⟷ q) : 𝓢 ⊢ (◇p ⟷ ◇q) := by
   simp only [StandardModalLogicalConnective.duality'];
-  apply negIff';
+  apply negReplaceIff';
   apply boxIff';
-  apply negIff';
+  apply negReplaceIff';
   assumption
 @[simp] lemma dia_iff! (h : 𝓢 ⊢! p ⟷ q) : 𝓢 ⊢! ◇p ⟷ ◇q := ⟨diaIff' h.some⟩
 
@@ -197,9 +197,9 @@ def multidiaDuality : 𝓢 ⊢ ◇^[n]p ⟷ ~(□^[n](~p)) := by
   | zero => simp; apply dn;
   | succ n ih =>
     simp [StandardModalLogicalConnective.duality'];
-    apply negIff';
+    apply negReplaceIff';
     apply boxIff';
-    exact iffTrans'' (negIff' ih) (iffComm' dn)
+    exact iffTrans'' (negReplaceIff' ih) (iffComm' dn)
 @[simp] lemma multidia_duality! : 𝓢 ⊢! ◇^[n]p ⟷ ~(□^[n](~p)) := ⟨multidiaDuality⟩
 
 def diaDuality : 𝓢 ⊢ ◇p ⟷ ~(□~p) := multidiaDuality (n := 1)
@@ -497,7 +497,7 @@ private def axiomFour_of_L [HasAxiomL 𝓢] : 𝓢 ⊢ Axioms.Four p := by
 instance [HasAxiomL 𝓢] : HasAxiomFour 𝓢 := ⟨fun _ ↦ axiomFour_of_L⟩
 
 def goedel2 [HasAxiomL 𝓢] : 𝓢 ⊢ (~(□⊥) ⟷ ~(□(~(□⊥))) : F) := by
-  apply negIff';
+  apply negReplaceIff';
   apply iffIntro;
   . apply implyBoxDistribute';
     exact efq;

--- a/Logic/Propositional/Superintuitionistic/Deduction.lean
+++ b/Logic/Propositional/Superintuitionistic/Deduction.lean
@@ -128,7 +128,7 @@ theorem iff_provable_dn_efq_dne_provable: 𝐈𝐧𝐭 ⊢! ~~p ↔ 𝐂𝐥 ⊢
         subst hq;
         apply FiniteContext.deduct'!;
         have : [~(q ⋎ ~q)] ⊢[𝐈𝐧𝐭]! ~q ⋏ ~~q := demorgan₃'! $ FiniteContext.id!;
-        exact (and₂'! this) ⨀ (and₁'! this);
+        exact neg_mdp! (and₂'! this) (and₁'! this);
     | @mdp p q h₁ h₂ ih₁ ih₂ =>
       exact (dn_distribute_imply'! $ ih₁ ⟨h₁⟩) ⨀ ih₂ ⟨h₂⟩;
     | _ => apply dni'!; simp;

--- a/Logic/Propositional/Superintuitionistic/Deduction.lean
+++ b/Logic/Propositional/Superintuitionistic/Deduction.lean
@@ -35,6 +35,7 @@ inductive Deduction (𝓓 : DeductionParameter α) : Formula α → Type _
   | or₁ p q      : Deduction 𝓓 $ p ⟶ p ⋎ q
   | or₂ p q      : Deduction 𝓓 $ q ⟶ p ⋎ q
   | or₃ p q r    : Deduction 𝓓 $ (p ⟶ r) ⟶ (q ⟶ r) ⟶ (p ⋎ q ⟶ r)
+  | neg_equiv p  : Deduction 𝓓 $ Axioms.NegEquiv p
 
 instance : System (Formula α) (DeductionParameter α) := ⟨Deduction⟩
 
@@ -54,6 +55,7 @@ instance : System.Minimal 𝓓 where
   or₁ := or₁
   or₂ := or₂
   or₃ := or₃
+  neg_equiv := neg_equiv
 
 instance [𝓓.IncludeEFQ] : System.HasAxiomEFQ 𝓓 where
   efq _ := eaxm $ Set.mem_of_subset_of_mem IncludeEFQ.include_EFQ (by simp);
@@ -126,6 +128,7 @@ theorem iff_provable_dn_efq_dne_provable: 𝐈𝐧𝐭 ⊢! ~~p ↔ 𝐂𝐥 ⊢
         exact dni'! efq!;
       . obtain ⟨q, hq⟩ := by simpa using hLEM;
         subst hq;
+        apply neg_equiv'!.mpr;
         apply FiniteContext.deduct'!;
         have : [~(q ⋎ ~q)] ⊢[𝐈𝐧𝐭]! ~q ⋏ ~~q := demorgan₃'! $ FiniteContext.id!;
         exact neg_mdp! (and₂'! this) (and₁'! this);

--- a/Logic/Propositional/Superintuitionistic/Formula.lean
+++ b/Logic/Propositional/Superintuitionistic/Formula.lean
@@ -161,7 +161,6 @@ instance : DecidableEq (Formula α) := hasDecEq
 
 end Decidable
 
-/-
 section Encodable
 
 open Sum
@@ -175,33 +174,30 @@ def Edge (α) : Node α → Type
   | (inr $ inr $ inl _) => Unit
   | (inr $ inr $ inr _) => Bool
 
-#check Bool.rec
-
 def toW : Formula α → WType (Edge α)
   | atom a  => ⟨inl a, Empty.elim⟩
   | falsum  => ⟨inr $ inl 0, Empty.elim⟩
   | verum   => ⟨inr $ inl 1, Empty.elim⟩
-  | neg p   => ⟨inr $ inr $ inl 0, p.toW⟩
+  | neg p   => ⟨inr $ inr $ inl 0, PUnit.rec p.toW⟩
   | imp p q => ⟨inr $ inr $ inr 0, Bool.rec p.toW q.toW⟩
   | or p q  => ⟨inr $ inr $ inr 1, Bool.rec p.toW q.toW⟩
   | and p q => ⟨inr $ inr $ inr 2, Bool.rec p.toW q.toW⟩
 
 def ofW : WType (Edge α) → Formula α
   | ⟨inl a, _⟩        => atom a
-  | ⟨inr $ inl 0, _⟩  => verum
-  | ⟨inr $ inl 1, _⟩  => falsum
+  | ⟨inr $ inl 0, _⟩ => falsum
+  | ⟨inr $ inl 1, _⟩  => verum
   | ⟨inr $ inr $ inl 0, p⟩ => neg (ofW $ p ())
   | ⟨inr $ inr $ inr 0, p⟩ => imp (ofW $ p false) (ofW $ p true)
   | ⟨inr $ inr $ inr 1, p⟩ => or  (ofW $ p false) (ofW $ p true)
   | ⟨inr $ inr $ inr 2, p⟩ => and (ofW $ p false) (ofW $ p true)
 
 lemma toW_ofW : ∀ (w : WType (Edge α)), toW (ofW w) = w
-  | ⟨inl a, _⟩         => by simp [ofW, toW, Empty.eq_elim];
-  | ⟨inr $ inl 0, _⟩   => by simp [ofW, toW, Empty.eq_elim];
-  | ⟨inr $ inl 1, _⟩   => by simp [ofW, toW, Empty.eq_elim];
+  | ⟨inl a, _⟩       => by simp [ofW, toW, Empty.eq_elim];
+  | ⟨inr $ inl 0, _⟩ => by simp [ofW, toW, Empty.eq_elim];
+  | ⟨inr $ inl 1, _⟩ => by simp [ofW, toW, Empty.eq_elim];
   | ⟨inr $ inr $ inl 0, w⟩ => by
-    simp [ofW, toW, toW_ofW (w false), toW_ofW (w true)];
-    ext b; cases b <;> simp;
+    simp [ofW, toW, toW_ofW (w ())];
   | ⟨inr $ inr $ inr 0, w⟩ => by
     simp [ofW, toW, toW_ofW (w false), toW_ofW (w true)];
     ext b; cases b <;> simp;
@@ -235,7 +231,6 @@ variable [Encodable α]
 instance : Encodable (Formula α) := Encodable.ofEquiv (WType (Edge α)) (equivW α)
 
 end Encodable
--/
 
 end Formula
 

--- a/Logic/Propositional/Superintuitionistic/Formula.lean
+++ b/Logic/Propositional/Superintuitionistic/Formula.lean
@@ -96,10 +96,10 @@ def rec' {C : Formula α → Sort w}
   (hfalsum : C ⊥)
   (hverum  : C ⊤)
   (hatom   : ∀ a : α, C (atom a))
-  (hneg   : ∀ p : Formula α, C p → C (~p))
+  (hneg    : ∀ p : Formula α, C p → C (~p))
   (himp    : ∀ (p q : Formula α), C p → C q → C (p ⟶ q))
-  (hand   : ∀ (p q : Formula α), C p → C q → C (p ⋏ q))
-  (hor    : ∀ (p q : Formula α), C p → C q → C (p ⋎ q))
+  (hand    : ∀ (p q : Formula α), C p → C q → C (p ⋏ q))
+  (hor     : ∀ (p q : Formula α), C p → C q → C (p ⋎ q))
   : (p : Formula α) → C p
   | ⊥       => hfalsum
   | ⊤       => hverum

--- a/Logic/Propositional/Superintuitionistic/Formula.lean
+++ b/Logic/Propositional/Superintuitionistic/Formula.lean
@@ -7,14 +7,13 @@ inductive Formula (α : Type u) : Type u
   | atom   : α → Formula α
   | verum  : Formula α
   | falsum : Formula α
+  | neg    : Formula α → Formula α
   | and    : Formula α → Formula α → Formula α
   | or     : Formula α → Formula α → Formula α
   | imp    : Formula α → Formula α → Formula α
   deriving DecidableEq
 
 namespace Formula
-
-@[simp] def neg (p : Formula α) : Formula α := imp p falsum
 
 instance : LogicalConnective (Formula α) where
   tilde := neg
@@ -24,8 +23,6 @@ instance : LogicalConnective (Formula α) where
   top := verum
   bot := falsum
 
-instance : NegAbbrev (Formula α) := ⟨rfl⟩
-
 section ToString
 
 variable [ToString α]
@@ -34,6 +31,7 @@ def toStr : Formula α → String
   | ⊤       => "\\top"
   | ⊥       => "\\bot"
   | atom a  => "{" ++ toString a ++ "}"
+  | ~p      => "\\lnot " ++ toStr p
   | p ⋏ q   => "\\left(" ++ toStr p ++ " \\land " ++ toStr q ++ "\\right)"
   | p ⋎ q   => "\\left(" ++ toStr p ++ " \\lor "  ++ toStr q ++ "\\right)"
   | p ⟶ q   => "\\left(" ++ toStr p ++ " \\rightarrow " ++ toStr q ++ "\\right)"
@@ -48,7 +46,7 @@ end ToString
 @[simp] lemma imp_inj (p₁ q₁ p₂ q₂ : Formula α) : p₁ ⟶ p₂ = q₁ ⟶ q₂ ↔ p₁ = q₁ ∧ p₂ = q₂ := by simp[Arrow.arrow]
 @[simp] lemma neg_inj (p q : Formula α) : ~p = ~q ↔ p = q := by simp[Tilde.tilde]
 
-lemma neg_def (p : Formula α) : ~p = p ⟶ ⊥ := rfl
+-- lemma neg_def (p : Formula α) : ~p = p ⟶ ⊥ := rfl
 
 lemma iff_def (p q : Formula α) : p ⟷ q = (p ⟶ q) ⋏ (q ⟶ p) := by rfl
 
@@ -56,6 +54,7 @@ def complexity : Formula α → ℕ
 | atom _  => 0
 | ⊤       => 0
 | ⊥       => 0
+| ~p      => p.complexity + 1
 | p ⟶ q  => max p.complexity q.complexity + 1
 | p ⋏ q   => max p.complexity q.complexity + 1
 | p ⋎ q   => max p.complexity q.complexity + 1
@@ -79,6 +78,7 @@ def cases' {C : Formula α → Sort w}
     (hfalsum : C ⊥)
     (hverum  : C ⊤)
     (hatom   : ∀ a : α, C (atom a))
+    (hneg    : ∀ p : Formula α, C (~p))
     (himp    : ∀ (p q : Formula α), C (p ⟶ q))
     (hand    : ∀ (p q : Formula α), C (p ⋏ q))
     (hor     : ∀ (p q : Formula α), C (p ⋎ q))
@@ -86,6 +86,7 @@ def cases' {C : Formula α → Sort w}
   | ⊥       => hfalsum
   | ⊤       => hverum
   | atom a  => hatom a
+  | ~p      => hneg p
   | p ⟶ q  => himp p q
   | p ⋏ q   => hand p q
   | p ⋎ q   => hor p q
@@ -95,6 +96,7 @@ def rec' {C : Formula α → Sort w}
   (hfalsum : C ⊥)
   (hverum  : C ⊤)
   (hatom   : ∀ a : α, C (atom a))
+  (hneg   : ∀ p : Formula α, C p → C (~p))
   (himp    : ∀ (p q : Formula α), C p → C q → C (p ⟶ q))
   (hand   : ∀ (p q : Formula α), C p → C q → C (p ⋏ q))
   (hor    : ∀ (p q : Formula α), C p → C q → C (p ⋎ q))
@@ -102,9 +104,10 @@ def rec' {C : Formula α → Sort w}
   | ⊥       => hfalsum
   | ⊤       => hverum
   | atom a  => hatom a
-  | p ⟶ q  => himp p q (rec' hfalsum hverum hatom himp hand hor p) (rec' hfalsum hverum hatom himp hand hor q)
-  | p ⋏ q   => hand p q (rec' hfalsum hverum hatom himp hand hor p) (rec' hfalsum hverum hatom himp hand hor q)
-  | p ⋎ q   => hor p q (rec' hfalsum hverum hatom himp hand hor p) (rec' hfalsum hverum hatom himp hand hor q)
+  | ~p      => hneg p (rec' hfalsum hverum hatom hneg himp hand hor p)
+  | p ⟶ q  => himp p q (rec' hfalsum hverum hatom hneg himp hand hor p) (rec' hfalsum hverum hatom hneg himp hand hor q)
+  | p ⋏ q   => hand p q (rec' hfalsum hverum hatom hneg himp hand hor p) (rec' hfalsum hverum hatom hneg himp hand hor q)
+  | p ⋎ q   => hor p q (rec' hfalsum hverum hatom hneg himp hand hor p) (rec' hfalsum hverum hatom hneg himp hand hor q)
 
 section Decidable
 
@@ -120,6 +123,12 @@ def hasDecEq : (p q : Formula α) → Decidable (p = q)
   | atom a, q => by
     cases q using cases' <;> try { simp; exact isFalse not_false }
     simp; exact decEq _ _
+  | ~p, q => by
+    cases q using cases' <;> try { simp; exact isFalse not_false }
+    case hneg p' =>
+      exact match hasDecEq p p' with
+      | isTrue hp  => isTrue (by simp[hp])
+      | isFalse hp => isFalse (by simp[hp])
   | p ⟶ q, r => by
     cases r using cases' <;> try { simp; exact isFalse not_false }
     case himp p' q' =>
@@ -152,43 +161,54 @@ instance : DecidableEq (Formula α) := hasDecEq
 
 end Decidable
 
+/-
 section Encodable
 
-abbrev Node (α) := α ⊕ Bool ⊕ Fin 3
+open Sum
+
+abbrev Node (α) := α ⊕ Fin 2 ⊕ Fin 1 ⊕ Fin 3
 
 @[reducible]
 def Edge (α) : Node α → Type
-  | (Sum.inl _)                => Empty
-  | (Sum.inr $ Sum.inl _)      => Empty
-  | (Sum.inr $ Sum.inr ⟨_, _⟩) => Bool
+  | (inl _)             => Empty
+  | (inr $ inl _)       => Empty
+  | (inr $ inr $ inl _) => Unit
+  | (inr $ inr $ inr _) => Bool
+
+#check Bool.rec
 
 def toW : Formula α → WType (Edge α)
-  | atom a  => ⟨Sum.inl a, Empty.elim⟩
-  | falsum  => ⟨Sum.inr $ Sum.inl false, Empty.elim⟩
-  | verum   => ⟨Sum.inr $ Sum.inl true, Empty.elim⟩
-  | imp p q => ⟨Sum.inr $ Sum.inr ⟨0, (by trivial)⟩, Bool.rec p.toW q.toW⟩
-  | or p q  => ⟨Sum.inr $ Sum.inr ⟨1, (by trivial)⟩, Bool.rec p.toW q.toW⟩
-  | and p q => ⟨Sum.inr $ Sum.inr ⟨2, (by trivial)⟩, Bool.rec p.toW q.toW⟩
+  | atom a  => ⟨inl a, Empty.elim⟩
+  | falsum  => ⟨inr $ inl 0, Empty.elim⟩
+  | verum   => ⟨inr $ inl 1, Empty.elim⟩
+  | neg p   => ⟨inr $ inr $ inl 0, p.toW⟩
+  | imp p q => ⟨inr $ inr $ inr 0, Bool.rec p.toW q.toW⟩
+  | or p q  => ⟨inr $ inr $ inr 1, Bool.rec p.toW q.toW⟩
+  | and p q => ⟨inr $ inr $ inr 2, Bool.rec p.toW q.toW⟩
 
 def ofW : WType (Edge α) → Formula α
-  | ⟨Sum.inl a, _⟩                => atom a
-  | ⟨Sum.inr $ Sum.inl true, _⟩   => verum
-  | ⟨Sum.inr $ Sum.inl false, _⟩  => falsum
-  | ⟨Sum.inr $ Sum.inr ⟨0, _⟩, p⟩ => imp (ofW $ p false) (ofW $ p true)
-  | ⟨Sum.inr $ Sum.inr ⟨1, _⟩, p⟩ => or (ofW $ p false) (ofW $ p true)
-  | ⟨Sum.inr $ Sum.inr ⟨2, _⟩, p⟩ => and (ofW $ p false) (ofW $ p true)
+  | ⟨inl a, _⟩        => atom a
+  | ⟨inr $ inl 0, _⟩  => verum
+  | ⟨inr $ inl 1, _⟩  => falsum
+  | ⟨inr $ inr $ inl 0, p⟩ => neg (ofW $ p ())
+  | ⟨inr $ inr $ inr 0, p⟩ => imp (ofW $ p false) (ofW $ p true)
+  | ⟨inr $ inr $ inr 1, p⟩ => or  (ofW $ p false) (ofW $ p true)
+  | ⟨inr $ inr $ inr 2, p⟩ => and (ofW $ p false) (ofW $ p true)
 
 lemma toW_ofW : ∀ (w : WType (Edge α)), toW (ofW w) = w
-  | ⟨Sum.inl a, _⟩                => by simp [ofW, toW, Empty.eq_elim];
-  | ⟨Sum.inr $ Sum.inl true, _⟩   => by simp [ofW, toW, Empty.eq_elim];
-  | ⟨Sum.inr $ Sum.inl false, _⟩  => by simp [ofW, toW, Empty.eq_elim];
-  | ⟨Sum.inr $ Sum.inr ⟨0, _⟩, w⟩ => by
+  | ⟨inl a, _⟩         => by simp [ofW, toW, Empty.eq_elim];
+  | ⟨inr $ inl 0, _⟩   => by simp [ofW, toW, Empty.eq_elim];
+  | ⟨inr $ inl 1, _⟩   => by simp [ofW, toW, Empty.eq_elim];
+  | ⟨inr $ inr $ inl 0, w⟩ => by
     simp [ofW, toW, toW_ofW (w false), toW_ofW (w true)];
     ext b; cases b <;> simp;
-  | ⟨Sum.inr $ Sum.inr ⟨1, _⟩, w⟩ => by
+  | ⟨inr $ inr $ inr 0, w⟩ => by
     simp [ofW, toW, toW_ofW (w false), toW_ofW (w true)];
     ext b; cases b <;> simp;
-  | ⟨Sum.inr $ Sum.inr ⟨2, _⟩, w⟩ => by
+  | ⟨inr $ inr $ inr 1, w⟩ => by
+    simp [ofW, toW, toW_ofW (w false), toW_ofW (w true)];
+    ext b; cases b <;> simp;
+  | ⟨inr $ inr $ inr 2, w⟩ => by
     simp [ofW, toW, toW_ofW (w false), toW_ofW (w true)];
     ext b; cases b <;> simp;
 
@@ -199,20 +219,23 @@ def equivW (α) : Formula α ≃ WType (Edge α) where
   left_inv := λ p => by induction p <;> simp_all [toW, ofW]
 
 instance : (a : Node α) → Fintype (Edge α a)
-  | (Sum.inl _)           => Fintype.ofIsEmpty
-  | (Sum.inr $ Sum.inl _) => Fintype.ofIsEmpty
-  | (Sum.inr $ Sum.inr _) => Bool.fintype
+  | (inl _)             => Fintype.ofIsEmpty
+  | (inr $ inl _)       => Fintype.ofIsEmpty
+  | (inr $ inr $ inl _) => Unit.fintype
+  | (inr $ inr $ inr _) => Bool.fintype
 
 instance : (a : Node α) → Primcodable (Edge α a)
-  | (Sum.inl _)           => Primcodable.empty
-  | (Sum.inr $ Sum.inl _) => Primcodable.empty
-  | (Sum.inr $ Sum.inr _) => Primcodable.bool
+  | (inl _)             => Primcodable.empty
+  | (inr $ inl _)       => Primcodable.empty
+  | (inr $ inr $ inl _) => Primcodable.unit
+  | (inr $ inr $ inr _) => Primcodable.bool
 
 variable [Encodable α]
 
 instance : Encodable (Formula α) := Encodable.ofEquiv (WType (Edge α)) (equivW α)
 
 end Encodable
+-/
 
 end Formula
 

--- a/Logic/Propositional/Superintuitionistic/Kripke/Classical.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Classical.lean
@@ -94,7 +94,7 @@ variable {V : ClassicalValuation α}
 @[simp] lemma and_def  : V ⊧ p ⋏ q ↔ V ⊧ p ∧ V ⊧ q := by simp
 @[simp] lemma or_def   : V ⊧ p ⋎ q ↔ V ⊧ p ∨ V ⊧ q := by simp
 @[simp] lemma imp_def  : V ⊧ p ⟶ q ↔ V ⊧ p → V ⊧ q := by simp; tauto;
-@[simp] lemma neg_def  : V ⊧ ~p ↔ ¬V ⊧ p := by simp only [NegAbbrev.neg, imp_def, bot_def];
+-- @[simp] lemma neg_def  : V ⊧ ~p ↔ ¬V ⊧ p := by simp;
 
 end Formula.Kripke.ClassicalSatisfies
 

--- a/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
@@ -485,7 +485,36 @@ private lemma truthlemma.himp
 private lemma truthlemma.hneg
   {t : (CanonicalModel 𝓓).World}
   (ihp : ∀ {t : (CanonicalModel 𝓓).World}, t ⊧ p ↔ p ∈ t.tableau.1)
-  : t ⊧ ~p ↔ ~p ∈ t.tableau.1 := by sorry;
+  : t ⊧ ~p ↔ ~p ∈ t.tableau.1 := by
+  constructor;
+  . contrapose; simp_all;
+    intro h;
+    replace h := t.not_mem₁_iff_mem₂.mp h;
+    obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (𝓓 := 𝓓) (t₀ := (insert p t.tableau.1, ∅)) $ by
+      simp only [Tableau.ParametricConsistent];
+      intro Γ Δ hΓ hΔ;
+      replace hΓ : ∀ q, q ∈ Γ.remove p → q ∈ t.tableau.1 := by
+        intro q hq;
+        have ⟨hq₁, hq₂⟩ := List.mem_remove_iff.mp hq;
+        have := by simpa using hΓ q hq₁;
+        simp_all;
+      replace hΔ : Δ = [] := List.nil_iff.mpr hΔ; subst hΔ;
+      by_contra hC; simp at hC;
+      have : 𝓓 ⊢! (Γ.remove p).conj' ⟶ ~p := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (and₂'! neg_equiv!);
+      have : 𝓓 ⊬! (Γ.remove p).conj' ⟶ ~p := by simpa only [List.disj'_singleton] using t.consistent (Δ := [~p]) hΓ (by simpa);
+      contradiction;
+    have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
+    existsi t';
+    constructor;
+    . simp_all only [Set.singleton_subset_iff];
+    . assumption;
+  . simp;
+    intro ht t' htt';
+    apply ihp.not.mpr;
+    by_contra hC;
+    have : 𝓓 ⊬! p ⋏ ~p ⟶ ⊥ := by simpa using t'.consistent (Γ := [p, ~p]) (Δ := []) (by aesop) (by simp);
+    have : 𝓓 ⊢! p ⋏ ~p ⟶ ⊥ := intro_bot_of_and!;
+    contradiction;
 
 lemma truthlemma {t : (CanonicalModel 𝓓).World} : t ⊧ p ↔ p ∈ t.tableau.1 := by
   induction p using rec' generalizing t with

--- a/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
@@ -430,52 +430,67 @@ variable [Inhabited (SCT 𝓓)]
 
 variable {t : SCT 𝓓}
 
+private lemma truthlemma.himp
+  {t : (CanonicalModel 𝓓).World}
+  (ihp : ∀ {t : (CanonicalModel 𝓓).World}, t ⊧ p ↔ p ∈ t.tableau.1)
+  (ihq : ∀ {t : (CanonicalModel 𝓓).World}, t ⊧ q ↔ q ∈ t.tableau.1)
+  : t ⊧ p ⟶ q ↔ p ⟶ q ∈ t.tableau.1 := by
+  constructor;
+  . contrapose;
+    simp_all;
+    intro h;
+    replace h := t.not_mem₁_iff_mem₂.mp h;
+    obtain ⟨t', ⟨h, _⟩⟩ := lindenbaum (𝓓 := 𝓓) (t₀ := (insert p t.tableau.1, {q})) $ by
+      simp only [Tableau.ParametricConsistent];
+      intro Γ Δ hΓ hΔ;
+      replace hΓ : ∀ r, r ∈ Γ.remove p → r ∈ t.tableau.1 := by
+        intro r hr;
+        have ⟨hr₁, hr₂⟩ := List.mem_remove_iff.mp hr;
+        have := by simpa using hΓ r hr₁;
+        simp_all;
+      by_contra hC;
+      have : 𝓓 ⊢! (Γ.remove p).conj' ⟶ (p ⟶ q) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (by
+        apply deduct'!;
+        apply deduct!;
+        have : [p, p ⟶ Δ.disj'] ⊢[𝓓]! p := by_axm!;
+        have : [p, p ⟶ Δ.disj'] ⊢[𝓓]! Δ.disj' := by_axm! ⨀ this;
+        exact disj_allsame'! (by simpa using hΔ) this;
+      )
+      have : 𝓓 ⊬! (Γ.remove p).conj' ⟶ (p ⟶ q) := by simpa only [List.disj'_singleton] using (t.consistent hΓ (show ∀ r ∈ [p ⟶ q], r ∈ t.tableau.2 by simp_all));
+      contradiction;
+    have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
+    existsi t';
+    constructor;
+    . simp_all only [Set.singleton_subset_iff];
+    . constructor;
+      . assumption;
+      . apply t'.not_mem₁_iff_mem₂.mpr;
+        simp_all only [Set.singleton_subset_iff];
+  . simp [Satisfies.imp_def];
+    intro h t' htt' hp;
+    replace hp := ihp.mp hp;
+    have hpq := htt' h;
+    apply ihq.mpr;
+    apply t'.not_mem₂_iff_mem₁.mp;
+    exact not_mem₂
+      (by simp_all)
+      (show 𝓓 ⊢! [p, p ⟶ q].conj' ⟶ q by
+        simp;
+        apply and_imply_iff_imply_imply'!.mpr;
+        apply deduct'!;
+        apply deduct!;
+        exact by_axm! ⨀ (by_axm! (p := p));
+      );
+
+private lemma truthlemma.hneg
+  {t : (CanonicalModel 𝓓).World}
+  (ihp : ∀ {t : (CanonicalModel 𝓓).World}, t ⊧ p ↔ p ∈ t.tableau.1)
+  : t ⊧ ~p ↔ ~p ∈ t.tableau.1 := by sorry;
+
 lemma truthlemma {t : (CanonicalModel 𝓓).World} : t ⊧ p ↔ p ∈ t.tableau.1 := by
   induction p using rec' generalizing t with
-  | himp p q ihp ihq =>
-    constructor;
-    . contrapose;
-      simp_all;
-      intro h;
-      replace h := t.not_mem₁_iff_mem₂.mp h;
-      have : (𝓓)-Consistent (insert p t.tableau.1, {q}) := by
-        simp only [Tableau.ParametricConsistent];
-        intro Γ Δ hΓ hΔ;
-        replace hΓ : ∀ r, r ∈ Γ.remove p → r ∈ t.tableau.1 := by
-          intro r hr;
-          have ⟨hr₁, hr₂⟩ := List.mem_remove_iff.mp hr;
-          have := by simpa using hΓ r hr₁;
-          simp_all;
-        by_contra hC;
-        have : 𝓓 ⊢! (Γ.remove p).conj' ⟶ (p ⟶ q) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (by
-          apply deduct'!;
-          apply deduct!;
-          have : [p, p ⟶ Δ.disj'] ⊢[𝓓]! p := by_axm! (by simp);
-          have : [p, p ⟶ Δ.disj'] ⊢[𝓓]! Δ.disj' := (by_axm! (by simp)) ⨀ this;
-          exact disj_allsame'! (by simpa using hΔ) this;
-        )
-        have : 𝓓 ⊬! (Γ.remove p).conj' ⟶ (p ⟶ q) := by simpa only [List.disj'_singleton] using (t.consistent hΓ (show ∀ r ∈ [p ⟶ q], r ∈ t.tableau.2 by simp_all));
-        contradiction;
-      obtain ⟨t', ⟨⟨_, _⟩, _⟩⟩ := by simpa [Set.insert_subset_iff] using lindenbaum this;
-      existsi t';
-      simp_all;
-      apply t'.not_mem₁_iff_mem₂.mpr;
-      assumption;
-    . simp [Satisfies.imp_def];
-      intro h t' htt' hp;
-      replace hp := ihp.mp hp;
-      have hpq := htt' h;
-      apply ihq.mpr;
-      apply t'.not_mem₂_iff_mem₁.mp;
-      exact not_mem₂
-        (by simp_all)
-        (show 𝓓 ⊢! [p, p ⟶ q].conj' ⟶ q by
-          simp;
-          apply and_imply_iff_imply_imply'!.mpr;
-          apply deduct'!;
-          apply deduct!;
-          exact by_axm! ⨀ (by_axm! (p := p));
-        );
+  | himp p q ihp ihq => exact truthlemma.himp ihp ihq
+  | hneg p ihp => exact truthlemma.hneg ihp;
   | _ => simp [Satisfies.iff_models, Satisfies, *];
 
 lemma deducible_of_validOnCanonicelModel : (CanonicalModel 𝓓) ⊧ p ↔ 𝓓 ⊢! p := by

--- a/Logic/Propositional/Superintuitionistic/Kripke/Semantics.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Semantics.lean
@@ -90,7 +90,8 @@ def Formula.Kripke.Satisfies (M : Kripke.Model α) (w : M.World) : Formula α �
   | ⊥      => False
   | p ⋏ q  => Satisfies M w p ∧ Satisfies M w q
   | p ⋎ q  => Satisfies M w p ∨ Satisfies M w q
-  | p ⟶ q => ∀ {w'}, (w ≺ w') → (¬Satisfies M w' p ∨ Satisfies M w' q)
+  | ~p     => ∀ {w'}, (w ≺ w') → ¬Satisfies M w' p
+  | p ⟶ q => ∀ {w'}, (w ≺ w') → (Satisfies M w' p → Satisfies M w' q)
 
 instance instKripkeSemanticsFormulaWorld (M : Model α) : Semantics (Formula α) (M.World) := ⟨fun w ↦ Formula.Kripke.Satisfies M w⟩
 
@@ -110,7 +111,7 @@ local infix:45 " ⊩ " => Formula.Kripke.Satisfies M
 @[simp] lemma and_def  : w ⊩ p ⋏ q ↔ w ⊩ p ∧ w ⊩ q := by simp [Satisfies];
 @[simp] lemma or_def   : w ⊩ p ⋎ q ↔ w ⊩ p ∨ w ⊩ q := by simp [Satisfies];
 @[simp] lemma imp_def  : w ⊩ p ⟶ q ↔ ∀ {w'}, (w ≺ w') → (w' ⊩ p → w' ⊩ q) := by simp [Satisfies, imp_iff_not_or];
-@[simp] lemma neg_def  : w ⊩ ~p ↔ ∀ {w'}, (w ≺ w') → ¬(w' ⊩ p) := by simp [NegAbbrev.neg];
+@[simp] lemma neg_def  : w ⊩ ~p ↔ ∀ {w'}, (w ≺ w') → ¬(w' ⊩ p) := by simp [Satisfies];
 
 instance : Semantics.Top M.World where
   realize_top := by simp [Satisfies];
@@ -131,6 +132,10 @@ lemma formula_hereditary (hw : w ≺ w') : w ⊩ p → w' ⊩ p := by
     simp_all [Satisfies];
     intro hpq v hv;
     exact hpq $ M.Frame.Rel_trans hw hv;
+  | hneg =>
+    simp_all [Satisfies];
+    intro hp v hv;
+    exact hp $ M.Frame.Rel_trans hw hv;
   | hor => simp_all [Satisfies]; tauto;
   | _ => simp_all [Satisfies];
 
@@ -191,6 +196,13 @@ variable {M : Model α} {p q r : Formula α}
   exact hpq _ (M.Frame.Rel_refl w);
 
 @[simp] protected lemma efq : M ⊧ Axioms.EFQ p := by simp_all [ValidOnModel];
+
+@[simp] protected lemma neg_equiv : M ⊧ Axioms.NegEquiv p := by
+  simp_all [ValidOnModel, Axioms.NegEquiv];
+  intro w;
+  constructor;
+  . intro x _ h y rxy hyp; exact h rxy hyp;
+  . intro x _ h y rxy; exact h rxy;
 
 @[simp] protected lemma lem (hExt : Extensive M.Rel) : M ⊧ Axioms.LEM p := by
   simp_all [ValidOnModel];
@@ -260,6 +272,10 @@ variable {F : Frame' α} {p q r : Formula α}
 @[simp] protected lemma efq : F ⊧ Axioms.EFQ p := by
   simp_all only [ValidOnFrame.models_iff, ValidOnFrame, ValidOnModel.iff_models];
   intros; apply ValidOnModel.efq;
+
+@[simp] protected lemma neg_equiv : F ⊧ Axioms.NegEquiv p := by
+  simp_all only [ValidOnFrame.models_iff, ValidOnFrame, ValidOnModel.iff_models];
+  intros; apply ValidOnModel.neg_equiv;
 
 @[simp] protected lemma lem (hExt : Extensive F.Rel) : F ⊧ Axioms.LEM p := by
   simp_all only [ValidOnFrame.models_iff, ValidOnFrame, ValidOnModel.iff_models];

--- a/Logic/Propositional/Superintuitionistic/Kripke/Semantics.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Semantics.lean
@@ -144,6 +144,8 @@ lemma hereditary_int {M : Model (𝐈𝐧𝐭 W α)} {w w' : W} {p : Formula α}
   apply hereditary (by simp [FrameClass.Intuitionistic]; tauto) hw;
 -/
 
+lemma neg_equiv : w ⊩ ~p ↔ w ⊩ p ⟶ ⊥ := by simp_all [Satisfies];
+
 end Formula.Kripke.Satisfies
 
 

--- a/Logic/Propositional/Superintuitionistic/Kripke/Soundness.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Soundness.lean
@@ -29,6 +29,7 @@ lemma sound (d : 𝓓 ⊢ p) : 𝔽(Ax(𝓓)) ⊧ p := by
     | apply ValidOnFrame.and₁
     | apply ValidOnFrame.and₂
     | apply ValidOnFrame.and₃
+    | apply ValidOnFrame.neg_equiv
 
 lemma sound! : (𝓓 ⊢! p) → 𝔽(Ax(𝓓)) ⊧ p := λ ⟨d⟩ => sound d
 

--- a/Logic/Propositional/Translation.lean
+++ b/Logic/Propositional/Translation.lean
@@ -12,6 +12,7 @@ def Formula.toClassical : Superintuitionistic.Formula α → Classical.Formula �
   | .atom a => Classical.Formula.atom a
   | ⊤              => ⊤
   | ⊥              => ⊥
+  | ~p             => ~p.toClassical
   | p ⋏ q          => p.toClassical ⋏ q.toClassical
   | p ⋎ q          => p.toClassical ⋎ q.toClassical
   | p ⟶ q          => p.toClassical ⟶ q.toClassical


### PR DESCRIPTION
`~p`を`p ⟶ ⊥`の略記として導入すると次のような定義を用いるときmatchなどが微妙に使えないため困る．

```lean
def complement : Formula α → Formula α
| ~p => p
| _ => ~p
```

そのためプリミティヴな記号として導入したい．

直観主義様相論理のようなものも考えるとしたら`◇`も略記として導入するのは止めて証明体系上同値および意味論上同値で定義し直したほうが良いかもしれない．