### PR TITLE
refactor: List Conjunction and Disjunction

### DIFF
--- a/Logic/FirstOrder/Incompleteness/DerivabilityCondition.lean
+++ b/Logic/FirstOrder/Incompleteness/DerivabilityCondition.lean
@@ -209,12 +209,12 @@ private lemma consistency_lemma_1 [T₀ ≼ U] [β.HilbertBernays T₀ U] : (U �
     exact contra₃'! $ imp_trans''! (Subtheory.prf! (𝓢 := T₀) formalized_consistent_of_existance_unprovable) H;
   . intro H;
     apply contra₀'!;
-    have : T₀ ⊢! ⦍β⦎σ ⋏ ⦍β⦎(~σ) ⟶ ⦍β⦎⊥ := imp_trans''! prov_collect_and $ prov_distribute_imply no_both!;
+    have : T₀ ⊢! ⦍β⦎σ ⋏ ⦍β⦎(~σ) ⟶ ⦍β⦎⊥ := imp_trans''! prov_collect_and $ prov_distribute_imply lac!;
     have : U ⊢! ⦍β⦎σ ⟶ ⦍β⦎(~σ) ⟶ ⦍β⦎⊥ := Subtheory.prf! $ and_imply_iff_imply_imply'!.mp $ this;
     exact this ⨀₁ H;
 
 private lemma consistency_lemma_2 : T₀ ⊢! (⦍β⦎σ ⟶ ⦍β⦎(~σ)) ⟶ ⦍β⦎σ ⟶ ⦍β⦎⊥ := by
-  have : T ⊢! σ ⟶ ~σ ⟶ ⊥ := and_imply_iff_imply_imply'!.mp no_both!
+  have : T ⊢! σ ⟶ ~σ ⟶ ⊥ := and_imply_iff_imply_imply'!.mp lac!
   have : T₀ ⊢! ⦍β⦎σ ⟶ ⦍β⦎(~σ ⟶ ⊥)  := prov_distribute_imply this;
   have : T₀ ⊢! ⦍β⦎σ ⟶ (⦍β⦎(~σ) ⟶ ⦍β⦎⊥) := imp_trans''! this D2;
 

--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -293,7 +293,7 @@ def conjImplyConj [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ
 instance [(𝓢 : S) → ModusPonens 𝓢] [(𝓢 : S) → HasAxiomEFQ 𝓢] : DeductiveExplosion S := ⟨fun b _ ↦ efq ⨀ b⟩
 
 
-def generalConj' [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ Γ.conj' ⟶ p :=
+def generalConj' [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢ ⋀Γ ⟶ p :=
   match Γ with
   | []     => by simp at h
   | [q]    => by simp_all; exact impId q;
@@ -304,7 +304,7 @@ def generalConj' [DecidableEq F] {Γ : List F} {p : F} (h : p ∈ Γ) : 𝓢 ⊢
     . have : p ∈ (r :: Γ) := by simpa [e] using h;
       exact impTrans'' and₂ (generalConj' this);
 
-def conjIntro' [DecidableEq F] (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 ⊢ p) : 𝓢 ⊢ Γ.conj' :=
+def conjIntro' [DecidableEq F] (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 ⊢ p) : 𝓢 ⊢ ⋀Γ :=
   match Γ with
   | []     => verum
   | [q]    => by apply b; simp;
@@ -312,7 +312,7 @@ def conjIntro' [DecidableEq F] (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 
     simp;
     exact andIntro (b q (by simp)) (conjIntro' _ (by aesop))
 
-def implyConj' [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ p ⟶ Γ.conj' :=
+def implyConj' [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ p ⟶ ⋀Γ :=
   match Γ with
   | []     => dhyp p verum
   | [q]    => by apply b; simp;
@@ -320,7 +320,7 @@ def implyConj' [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ �
     simp;
     apply implyAnd (b q (by simp)) (implyConj' p _ (fun q hq ↦ b q (by simp [hq])));
 
-def conjImplyConj' [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ Γ.conj' ⟶ Δ.conj' :=
+def conjImplyConj' [DecidableEq F] {Γ Δ : List F} (h : Δ ⊆ Γ) : 𝓢 ⊢ ⋀Γ ⟶ ⋀Δ :=
   implyConj' _ _ (fun _ hq ↦ generalConj' (h hq))
 
 

--- a/Logic/Logic/HilbertStyle/Basic.lean
+++ b/Logic/Logic/HilbertStyle/Basic.lean
@@ -311,6 +311,7 @@ def conjIntro' [DecidableEq F] (Γ : List F) (b : (p : F) → p ∈ Γ → 𝓢 
   | q :: r :: Γ => by
     simp;
     exact andIntro (b q (by simp)) (conjIntro' _ (by aesop))
+lemma conj_intro'! [DecidableEq F] {Γ : List F} (b : (p : F) → p ∈ Γ → 𝓢 ⊢! p) : 𝓢 ⊢! ⋀Γ := ⟨conjIntro' Γ (λ p hp => (b p hp).some)⟩
 
 def implyConj' [DecidableEq F] (p : F) (Γ : List F) (b : (q : F) → q ∈ Γ → 𝓢 ⊢ p ⟶ q) : 𝓢 ⊢ p ⟶ ⋀Γ :=
   match Γ with

--- a/Logic/Logic/HilbertStyle/Context.lean
+++ b/Logic/Logic/HilbertStyle/Context.lean
@@ -18,9 +18,9 @@ variable {𝓢 : S}
 
 instance : Coe (List F) (FiniteContext F 𝓢) := ⟨mk⟩
 
-abbrev conj (Γ : FiniteContext F 𝓢) : F := Γ.ctx.conj'
+abbrev conj (Γ : FiniteContext F 𝓢) : F := ⋀Γ.ctx
 
-abbrev disj (Γ : FiniteContext F 𝓢) : F := Γ.ctx.disj'
+abbrev disj (Γ : FiniteContext F 𝓢) : F := ⋁Γ.ctx
 
 instance : EmptyCollection (FiniteContext F 𝓢) := ⟨⟨[]⟩⟩
 
@@ -67,13 +67,13 @@ notation Γ:45 " ⊢[" 𝓢 "]*! " s:46 => ProvableSet 𝓢 Γ s
 
 lemma system_def (Γ : FiniteContext F 𝓢) (p : F) : (Γ ⊢ p) = (𝓢 ⊢ Γ.conj ⟶ p) := rfl
 
-def ofDef {Γ : List F} {p : F} (b : 𝓢 ⊢ Γ.conj' ⟶ p) : Γ ⊢[𝓢] p := b
+def ofDef {Γ : List F} {p : F} (b : 𝓢 ⊢ ⋀Γ ⟶ p) : Γ ⊢[𝓢] p := b
 
-def toDef {Γ : List F} {p : F} (b : Γ ⊢[𝓢] p) : 𝓢 ⊢ Γ.conj' ⟶ p := b
+def toDef {Γ : List F} {p : F} (b : Γ ⊢[𝓢] p) : 𝓢 ⊢ ⋀Γ ⟶ p := b
 
-lemma toₛ! (b : Γ ⊢[𝓢]! p) : 𝓢 ⊢! Γ.conj' ⟶ p := b
+lemma toₛ! (b : Γ ⊢[𝓢]! p) : 𝓢 ⊢! ⋀Γ ⟶ p := b
 
-lemma provable_iff {p : F} : Γ ⊢[𝓢]! p ↔ 𝓢 ⊢! Γ.conj' ⟶ p := iff_of_eq rfl
+lemma provable_iff {p : F} : Γ ⊢[𝓢]! p ↔ 𝓢 ⊢! ⋀Γ ⟶ p := iff_of_eq rfl
 
 section minimal
 
@@ -97,7 +97,7 @@ def weakening (h : Γ ⊆ Δ) {p} : Γ ⊢[𝓢] p → Δ ⊢[𝓢] p := Axiomat
 
 lemma weakening! (h : Γ ⊆ Δ) {p} : Γ ⊢[𝓢]! p → Δ ⊢[𝓢]! p := fun h ↦ Axiomatized.le_of_subset (by simpa) h
 
-def of {p : F} (b : 𝓢 ⊢ p) : Γ ⊢[𝓢] p := dhyp Γ.conj' b
+def of {p : F} (b : 𝓢 ⊢ p) : Γ ⊢[𝓢] p := dhyp (⋀Γ) b
 
 def emptyPrf {p : F} : [] ⊢[𝓢] p → 𝓢 ⊢ p := fun b ↦ b ⨀ verum
 

--- a/Logic/Logic/HilbertStyle/Supplemental.lean
+++ b/Logic/Logic/HilbertStyle/Supplemental.lean
@@ -11,6 +11,7 @@ variable {F : Type*} [LogicalConnective F] [DecidableEq F]
 
 open NegationEquiv
 open FiniteContext
+open List
 
 def bot_of_mem_either [System.NegationEquiv 𝓢] (h₁ : p ∈ Γ) (h₂ : ~p ∈ Γ) : Γ ⊢[𝓢] ⊥ := by
   have hp : Γ ⊢[𝓢] p := FiniteContext.byAxm h₁;
@@ -361,18 +362,18 @@ def andImplyAndOfImply {p q p' q' : F} (bp : 𝓢 ⊢ p ⟶ p') (bq : 𝓢 ⊢ q
 def andIffAndOfIff {p q p' q' : F} (bp : 𝓢 ⊢ p ⟷ p') (bq : 𝓢 ⊢ q ⟷ q') : 𝓢 ⊢ p ⋏ q ⟷ p' ⋏ q' :=
   iffIntro (andImplyAndOfImply (andLeft bp) (andLeft bq)) (andImplyAndOfImply (andRight bp) (andRight bq))
 
-def conj'IffConj : (Γ : List F) → 𝓢 ⊢ Γ.conj' ⟷ Γ.conj
+def conj'IffConj : (Γ : List F) → 𝓢 ⊢ ⋀Γ ⟷ Γ.conj
   | []          => iffId ⊤
   | [_]         => iffIntro (deduct' <| andIntro FiniteContext.id verum) and₁
   | p :: q :: Γ => andIffAndOfIff (iffId p) (conj'IffConj (q :: Γ))
-@[simp] lemma conj'IffConj! : 𝓢 ⊢! Γ.conj' ⟷ Γ.conj := ⟨conj'IffConj Γ⟩
+@[simp] lemma conj'IffConj! : 𝓢 ⊢! ⋀Γ ⟷ Γ.conj := ⟨conj'IffConj Γ⟩
 
 
-lemma implyLeft_conj_eq_conj'! : 𝓢 ⊢! Γ.conj ⟶ p ↔ 𝓢 ⊢! Γ.conj' ⟶ p := replace_imply_left_by_iff'! $ iff_comm'! conj'IffConj!
+lemma implyLeft_conj_eq_conj'! : 𝓢 ⊢! Γ.conj ⟶ p ↔ 𝓢 ⊢! ⋀Γ ⟶ p := replace_imply_left_by_iff'! $ iff_comm'! conj'IffConj!
 
 
-lemma generalConj'! (h : p ∈ Γ) : 𝓢 ⊢! Γ.conj' ⟶ p := replace_imply_left_by_iff'! conj'IffConj! |>.mpr (generalConj! h)
-lemma generalConj'₂! (h : p ∈ Γ) (d : 𝓢 ⊢! Γ.conj') : 𝓢 ⊢! p := (generalConj'! h) ⨀ d
+lemma generalConj'! (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ⟶ p := replace_imply_left_by_iff'! conj'IffConj! |>.mpr (generalConj! h)
+lemma generalConj'₂! (h : p ∈ Γ) (d : 𝓢 ⊢! ⋀Γ) : 𝓢 ⊢! p := (generalConj'! h) ⨀ d
 
 
 namespace Context
@@ -389,7 +390,7 @@ lemma emptyPrf! {p : F} : ∅ *⊢[𝓢]! p ↔ 𝓢 ⊢! p := by
 
 end Context
 
-lemma iff_provable_list_conj {Γ : List F} : (𝓢 ⊢! Γ.conj') ↔ (∀ p ∈ Γ, 𝓢 ⊢! p) := by
+lemma iff_provable_list_conj {Γ : List F} : (𝓢 ⊢! ⋀Γ) ↔ (∀ p ∈ Γ, 𝓢 ⊢! p) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle => simp;
@@ -403,7 +404,7 @@ lemma iff_provable_list_conj {Γ : List F} : (𝓢 ⊢! Γ.conj') ↔ (∀ p ∈
     . rintro ⟨h₁, h₂⟩;
       exact and₃'! h₁ (ih.mpr h₂);
 
-lemma conj'conj'_subset (h : ∀ p, p ∈ Γ → p ∈ Δ) : 𝓢 ⊢! Δ.conj' ⟶ Γ.conj' := by
+lemma conj'conj'_subset (h : ∀ p, p ∈ Γ → p ∈ Δ) : 𝓢 ⊢! ⋀Δ ⟶ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hnil => simpa using dhyp! verum!;
   | hsingle => simp_all; exact generalConj'! h;
@@ -465,20 +466,20 @@ lemma cut! (d₁ : 𝓢 ⊢! p₁ ⋏ c ⟶ q₁) (d₂ : 𝓢 ⊢! p₂ ⟶ c �
 
 lemma imply_left_and_comm'! (d : 𝓢 ⊢! p ⋏ q ⟶ r) : 𝓢 ⊢! q ⋏ p ⟶ r := imp_trans''! and_comm! d
 
-lemma id_conj'! (he : ∀ g ∈ Γ, g = p) : 𝓢 ⊢! p ⟶ Γ.conj' := by
+lemma id_conj'! (he : ∀ g ∈ Γ, g = p) : 𝓢 ⊢! p ⟶ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp_all only [List.conj'_nil, IsEmpty.forall_iff, forall_const]; exact dhyp! $ verum!;
-  | hsingle => simp_all only [List.mem_singleton, forall_eq, List.conj'_singleton, imp_id!];
+  | hnil => simp_all only [conj'_nil, IsEmpty.forall_iff, forall_const]; exact dhyp! $ verum!;
+  | hsingle => simp_all only [List.mem_singleton, forall_eq, conj'_singleton, imp_id!];
   | hcons r Γ h ih =>
-    simp [List.conj'_cons_nonempty h];
+    simp [conj'_cons_nonempty h];
     simp at he;
     have ⟨he₁, he₂⟩ := he;
     subst he₁;
     exact imply_right_and! imp_id! (ih he₂);
 
-lemma replace_imply_left_conj'! (he : ∀ g ∈ Γ, g = p) (hd : 𝓢 ⊢! Γ.conj' ⟶ q) : 𝓢 ⊢! p ⟶ q := imp_trans''! (id_conj'! he) hd
+lemma replace_imply_left_conj'! (he : ∀ g ∈ Γ, g = p) (hd : 𝓢 ⊢! ⋀Γ ⟶ q) : 𝓢 ⊢! p ⟶ q := imp_trans''! (id_conj'! he) hd
 
-lemma implyLeft_cons_conj'! : 𝓢 ⊢! (p :: Γ).conj' ⟶ q ↔ 𝓢 ⊢! p ⋏ Γ.conj' ⟶ q := by
+lemma implyLeft_cons_conj'! : 𝓢 ⊢! ⋀(p :: Γ) ⟶ q ↔ 𝓢 ⊢! p ⋏ ⋀Γ ⟶ q := by
   induction Γ with
   | nil =>
     simp [and_imply_iff_imply_imply'!];
@@ -487,9 +488,9 @@ lemma implyLeft_cons_conj'! : 𝓢 ⊢! (p :: Γ).conj' ⟶ q ↔ 𝓢 ⊢! p �
     . intro h; exact imp_swap'! h ⨀ verum!;
   | cons q ih => simp;
 
-lemma imply_left_concat_conj'! : 𝓢 ⊢! (Γ ++ Δ).conj' ⟶ Γ.conj' ⋏ Δ.conj' := by
+lemma imply_left_concat_conj'! : 𝓢 ⊢! ⋀(Γ ++ Δ) ⟶ ⋀Γ ⋏ ⋀Δ := by
   apply FiniteContext.deduct'!;
-  have : [(Γ ++ Δ).conj'] ⊢[𝓢]! (Γ ++ Δ).conj' := id!;
+  have : [⋀(Γ ++ Δ)] ⊢[𝓢]! ⋀(Γ ++ Δ) := id!;
   have d := iff_provable_list_conj.mp this;
   apply and₃'!;
   . apply iff_provable_list_conj.mpr;
@@ -500,7 +501,7 @@ lemma imply_left_concat_conj'! : 𝓢 ⊢! (Γ ++ Δ).conj' ⟶ Γ.conj' ⋏ Δ.
     exact d p (by simp; right; exact hp);
 
 @[simp]
-lemma forthback_conj_remove! : 𝓢 ⊢! (Γ.remove p).conj' ⋏ p ⟶ Γ.conj' := by
+lemma forthback_conj_remove! : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ⟶ ⋀Γ := by
   apply deduct'!;
   apply iff_provable_list_conj.mpr;
   intro q hq;
@@ -508,9 +509,9 @@ lemma forthback_conj_remove! : 𝓢 ⊢! (Γ.remove p).conj' ⋏ p ⟶ Γ.conj' 
   . subst e; exact and₂'! id!;
   . exact iff_provable_list_conj.mp (and₁'! id!) q (by apply List.mem_remove_iff.mpr; simp_all);
 
-lemma imply_left_remove_conj'! (b : 𝓢 ⊢! Γ.conj' ⟶ q) : 𝓢 ⊢! (Γ.remove p).conj' ⋏ p ⟶ q := imp_trans''! forthback_conj_remove! b
+lemma imply_left_remove_conj'! (b : 𝓢 ⊢! ⋀Γ ⟶ q) : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ⟶ q := imp_trans''! forthback_conj_remove! b
 
-lemma iff_concat_conj'! : 𝓢 ⊢! (Γ ++ Δ).conj' ↔ 𝓢 ⊢! Γ.conj' ⋏ Δ.conj' := by
+lemma iff_concat_conj'! : 𝓢 ⊢! ⋀(Γ ++ Δ) ↔ 𝓢 ⊢! ⋀Γ ⋏ ⋀Δ := by
   constructor;
   . intro h;
     replace h := iff_provable_list_conj.mp h;
@@ -526,7 +527,7 @@ lemma iff_concat_conj'! : 𝓢 ⊢! (Γ ++ Δ).conj' ↔ 𝓢 ⊢! Γ.conj' ⋏ 
     . exact (iff_provable_list_conj.mp $ and₁'! h) p hp₁;
     . exact (iff_provable_list_conj.mp $ and₂'! h) p hp₂;
 
-lemma iff_concat_conj! : 𝓢 ⊢! (Γ ++ Δ).conj' ⟷ Γ.conj' ⋏ Δ.conj' := by
+lemma iff_concat_conj! : 𝓢 ⊢! ⋀(Γ ++ Δ) ⟷ ⋀Γ ⋏ ⋀Δ := by
   apply iff_intro!;
   . apply deduct'!; apply iff_concat_conj'!.mp; exact id!;
   . apply deduct'!; apply iff_concat_conj'!.mpr; exact id!;
@@ -546,35 +547,35 @@ lemma or_replace_left_iff! (d : 𝓢 ⊢! p ⟷ r) : 𝓢 ⊢! p ⋎ q ⟷ r ⋎
   . apply or_replace_left!; exact and₁'! d;
   . apply or_replace_left!; exact and₂'! d;
 
-lemma iff_concact_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! (Γ ++ Δ).disj' ⟷ Γ.disj' ⋎ Δ.disj' := by
+lemma iff_concact_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ⟷ ⋁Γ ⋎ ⋁Δ := by
   induction Γ using List.induction_with_singleton generalizing Δ <;> induction Δ using List.induction_with_singleton;
   case hnil.hnil =>
-    simp only [List.append_nil, List.disj'_nil];
+    simp only [List.append_nil, disj'_nil];
     apply iff_intro!;
     . simp;
     . exact or₃''! efq! efq!;
   case hnil.hsingle =>
-    simp only [List.nil_append, List.disj'_singleton, List.disj'_nil];
+    simp only [List.nil_append, disj'_singleton, disj'_nil];
     apply iff_intro!;
     . simp;
     . exact or₃''! efq! imp_id!;
   case hsingle.hnil =>
-    simp only [List.singleton_append, List.disj'_singleton, List.disj'_nil];
+    simp only [List.singleton_append, disj'_singleton, disj'_nil];
     apply iff_intro!;
     . simp;
     . exact or₃''! imp_id! efq!;
   case hcons.hnil =>
-    simp only [List.append_nil, List.disj'_nil];
+    simp only [List.append_nil, disj'_nil];
     apply iff_intro!;
     . simp;
     . exact or₃''! imp_id! efq!;
   case hnil.hcons =>
-    simp only [List.nil_append, List.disj'_nil];
+    simp only [List.nil_append, disj'_nil];
     apply iff_intro!;
     . simp;
     . exact or₃''! efq! imp_id!;
-  case hsingle.hsingle => simp only [List.singleton_append, ne_eq, not_false_eq_true, List.disj'_cons_nonempty, List.disj'_singleton, iff_id!];
-  case hsingle.hcons => simp only [List.singleton_append, ne_eq, not_false_eq_true, List.disj'_cons_nonempty, List.disj'_singleton, iff_id!];
+  case hsingle.hsingle => simp only [List.singleton_append, ne_eq, not_false_eq_true, disj'_cons_nonempty, disj'_singleton, iff_id!];
+  case hsingle.hcons => simp only [List.singleton_append, ne_eq, not_false_eq_true, disj'_cons_nonempty, disj'_singleton, iff_id!];
   case hcons.hsingle p ps hps ihp q =>
     simp_all;
     apply iff_trans''! (by
@@ -582,21 +583,21 @@ lemma iff_concact_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! (Γ ++ Δ).disj' ⟷ Γ.d
       simpa using @ihp [q];
     ) or_assoc!;
   case hcons.hcons p ps hps ihp q qs hqs ihq =>
-    simp_all only [ne_eq, List.cons_append, List.append_eq_nil, and_self, not_false_eq_true, List.disj'_cons_nonempty];
+    simp_all only [ne_eq, List.cons_append, List.append_eq_nil, and_self, not_false_eq_true, disj'_cons_nonempty];
     apply iff_trans''! (by
       apply or_replace_right_iff!;
       exact iff_trans''! (@ihp (q :: qs)) (by
         apply or_replace_right_iff!;
-        simp [List.disj'_cons_nonempty hqs];
+        simp [disj'_cons_nonempty hqs];
       )
     ) or_assoc!;
 
-lemma iff_concact_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! (Γ ++ Δ).disj' ↔ 𝓢 ⊢! Γ.disj' ⋎ Δ.disj' := by
+lemma iff_concact_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ↔ 𝓢 ⊢! ⋁Γ ⋎ ⋁Δ := by
   constructor;
   . intro h; exact (and₁'! iff_concact_disj!) ⨀ h;
   . intro h; exact (and₂'! iff_concact_disj!) ⨀ h;
 
-lemma implyRight_cons_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ⟶ (q :: Γ).disj' ↔ 𝓢 ⊢! p ⟶ q ⋎ Γ.disj' := by
+lemma implyRight_cons_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ⟶ ⋁(q :: Γ) ↔ 𝓢 ⊢! p ⟶ q ⋎ ⋁Γ := by
   induction Γ with
   | nil =>
     simp;
@@ -606,7 +607,7 @@ lemma implyRight_cons_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ⟶ (q :: Γ).disj
   | cons q ih => simp;
 
 @[simp]
-lemma forthback_disj'_remove [HasAxiomEFQ 𝓢] : 𝓢 ⊢! Γ.disj' ⟶ p ⋎ (Γ.remove p).disj' := by
+lemma forthback_disj'_remove [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁Γ ⟶ p ⋎ ⋁(Γ.remove p) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle q =>
@@ -615,22 +616,22 @@ lemma forthback_disj'_remove [HasAxiomEFQ 𝓢] : 𝓢 ⊢! Γ.disj' ⟶ p ⋎ (
     . subst_vars; simp;
     . simp [(List.remove_singleton_of_ne h)];
   | hcons q Γ h ih =>
-    simp [(List.disj'_cons_nonempty h)];
+    simp [(disj'_cons_nonempty h)];
     by_cases hpq : q = p;
     . simp_all only [ne_eq, List.remove_cons_self]; exact or₃''! or₁! ih;
     . simp_all [(List.remove_cons_of_ne Γ hpq)];
       by_cases hqΓ : Γ.remove p = [];
       . simp_all;
         exact or₃''! or₂! (imp_trans''! ih $ or_replace_right! efq!);
-      . simp [(List.disj'_cons_nonempty hqΓ)];
+      . simp [(disj'_cons_nonempty hqΓ)];
         exact or₃''! (imp_trans''! or₁! or₂!) (imp_trans''! ih (or_replace_right! or₂!));
 
-lemma disj_allsame! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) : 𝓢 ⊢! Γ.disj' ⟶ p := by
+lemma disj_allsame! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) : 𝓢 ⊢! ⋁Γ ⟶ p := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp_all [List.disj'_nil, efq!];
-  | hsingle => simp_all [List.mem_singleton, List.disj'_singleton, imp_id!];
+  | hnil => simp_all [disj'_nil, efq!];
+  | hsingle => simp_all [List.mem_singleton, disj'_singleton, imp_id!];
   | hcons q Δ hΔ ih =>
-    simp [List.disj'_cons_nonempty hΔ];
+    simp [disj'_cons_nonempty hΔ];
     simp at hd;
     have ⟨hd₁, hd₂⟩ := hd;
     subst hd₁;
@@ -638,7 +639,7 @@ lemma disj_allsame! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) : 𝓢 ⊢! Γ
     apply deduct_iff.mpr;
     exact or₃'''! (by simp) (weakening! (by simp) $ provable_iff_provable.mp $ ih hd₂) id!
 
-lemma disj_allsame'! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) (h : 𝓢 ⊢! Γ.disj') : 𝓢 ⊢! p := (disj_allsame! hd) ⨀ h
+lemma disj_allsame'! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) (h : 𝓢 ⊢! ⋁Γ) : 𝓢 ⊢! p := (disj_allsame! hd) ⨀ h
 
 instance [HasAxiomDNE 𝓢] : HasAxiomEFQ 𝓢 where
   efq p := by

--- a/Logic/Logic/HilbertStyle/Supplemental.lean
+++ b/Logic/Logic/HilbertStyle/Supplemental.lean
@@ -36,6 +36,37 @@ def neg_mdp [System.NegationEquiv 𝓢] (hnp : 𝓢 ⊢ ~p) (hn : 𝓢 ⊢ p) : 
 lemma neg_mdp! [System.NegationEquiv 𝓢] (hnp : 𝓢 ⊢! ~p) (hn : 𝓢 ⊢! p) : 𝓢 ⊢! ⊥ := ⟨neg_mdp hnp.some hn.some⟩
 -- infixl:90 "⨀" => neg_mdp!
 
+def dneOr [HasAxiomDNE 𝓢] (d : 𝓢 ⊢ ~~p ⋎ ~~q) : 𝓢 ⊢ p ⋎ q := or₃''' (impTrans'' dne or₁) (impTrans'' dne or₂) d
+
+def implyLeftOr' (h : 𝓢 ⊢ p ⟶ r) : 𝓢 ⊢ p ⟶ (r ⋎ q) := by
+  apply deduct';
+  apply or₁';
+  apply deductInv;
+  exact of h;
+lemma imply_left_or'! (h : 𝓢 ⊢! p ⟶ r) : 𝓢 ⊢! p ⟶ (r ⋎ q) := ⟨implyLeftOr' h.some⟩
+
+def implyRightOr' (h : 𝓢 ⊢ q ⟶ r) : 𝓢 ⊢ q ⟶ (p ⋎ r) := by
+  apply deduct';
+  apply or₂';
+  apply deductInv;
+  exact of h;
+lemma imply_right_or'! (h : 𝓢 ⊢! q ⟶ r) : 𝓢 ⊢! q ⟶ (p ⋎ r) := ⟨implyRightOr' h.some⟩
+
+
+def implyRightAnd (hq : 𝓢 ⊢ p ⟶ q) (hr : 𝓢 ⊢ p ⟶ r) : 𝓢 ⊢ p ⟶ q ⋏ r := by
+  apply deduct';
+  replace hq : [] ⊢[𝓢] p ⟶ q := of hq;
+  replace hr : [] ⊢[𝓢] p ⟶ r := of hr;
+  exact and₃' (mdp' hq FiniteContext.id) (mdp' hr FiniteContext.id)
+lemma imply_right_and! (hq : 𝓢 ⊢! p ⟶ q) (hr : 𝓢 ⊢! p ⟶ r) : 𝓢 ⊢! p ⟶ q ⋏ r := ⟨implyRightAnd hq.some hr.some⟩
+
+lemma imply_left_and_comm'! (d : 𝓢 ⊢! p ⋏ q ⟶ r) : 𝓢 ⊢! q ⋏ p ⟶ r := imp_trans''! and_comm! d
+
+lemma cut! (d₁ : 𝓢 ⊢! p₁ ⋏ c ⟶ q₁) (d₂ : 𝓢 ⊢! p₂ ⟶ c ⋎ q₂) : 𝓢 ⊢! p₁ ⋏ p₂ ⟶ q₁ ⋎ q₂ := by
+  apply deduct'!;
+  exact or₃'''! (imply_left_or'! $ of'! (and_imply_iff_imply_imply'!.mp d₁) ⨀ (and₁'! id!)) or₂! (of'! d₂ ⨀ and₂'! id!);
+
+@[simp] lemma imply_left_verum : 𝓢 ⊢! p ⟶ ⊤ := dhyp! $ verum!
 
 def orComm : 𝓢 ⊢ p ⋎ q ⟶ q ⋎ p := by
   apply deduct';
@@ -45,12 +76,43 @@ lemma or_comm! : 𝓢 ⊢! p ⋎ q ⟶ q ⋎ p := ⟨orComm⟩
 def orComm' (h : 𝓢 ⊢ p ⋎ q) : 𝓢 ⊢ q ⋎ p := orComm ⨀ h
 lemma or_comm'! (h : 𝓢 ⊢! p ⋎ q) : 𝓢 ⊢! q ⋎ p := ⟨orComm' h.some⟩
 
-def implyRightAnd (hq : 𝓢 ⊢ p ⟶ q) (hr : 𝓢 ⊢ p ⟶ r) : 𝓢 ⊢ p ⟶ q ⋏ r := by
-  apply deduct';
-  replace hq : [] ⊢[𝓢] p ⟶ q := of hq;
-  replace hr : [] ⊢[𝓢] p ⟶ r := of hr;
-  exact and₃' (mdp' hq FiniteContext.id) (mdp' hr FiniteContext.id)
-lemma imply_right_and! (hq : 𝓢 ⊢! p ⟶ q) (hr : 𝓢 ⊢! p ⟶ r) : 𝓢 ⊢! p ⟶ q ⋏ r := ⟨implyRightAnd hq.some hr.some⟩
+
+lemma or_assoc'! : 𝓢 ⊢! p ⋎ (q ⋎ r) ↔ 𝓢 ⊢! (p ⋎ q) ⋎ r := by
+  constructor;
+  . intro h;
+    exact or₃'''!
+      (imply_left_or'! $ imply_left_or'! imp_id!)
+      (by
+        apply provable_iff_provable.mpr;
+        apply deduct_iff.mpr;
+        exact or₃'''! (imply_left_or'! $ imply_right_or'! imp_id!) (imply_right_or'! imp_id!) id!;
+      )
+      h;
+  . intro h;
+    exact or₃'''!
+      (by
+        apply provable_iff_provable.mpr;
+        apply deduct_iff.mpr;
+        exact or₃'''! (imply_left_or'! imp_id!) (imply_right_or'! $ imply_left_or'! imp_id!) id!;
+      )
+      (imply_right_or'! $ imply_right_or'! imp_id!)
+      h;
+
+
+lemma and_assoc! : 𝓢 ⊢! (p ⋏ q) ⋏ r ⟷ p ⋏ (q ⋏ r) := by
+  apply iff_intro!;
+  . apply FiniteContext.deduct'!;
+    have hp : [(p ⋏ q) ⋏ r] ⊢[𝓢]! p := and₁'! $ and₁'! id!;
+    have hq : [(p ⋏ q) ⋏ r] ⊢[𝓢]! q := and₂'! $ and₁'! id!;
+    have hr : [(p ⋏ q) ⋏ r] ⊢[𝓢]! r := and₂'! id!;
+    exact and₃'! hp (and₃'! hq hr);
+  . apply FiniteContext.deduct'!;
+    have hp : [p ⋏ (q ⋏ r)] ⊢[𝓢]! p := and₁'! id!;
+    have hq : [p ⋏ (q ⋏ r)] ⊢[𝓢]! q := and₁'! $ and₂'! id!;
+    have hr : [p ⋏ (q ⋏ r)] ⊢[𝓢]! r := and₂'! $ and₂'! id!;
+    apply and₃'!;
+    . exact and₃'! hp hq;
+    . exact hr;
 
 
 def andReplaceLeft' (hc : 𝓢 ⊢ p ⋏ q) (h : 𝓢 ⊢ p ⟶ r) : 𝓢 ⊢ r ⋏ q := and₃' (h ⨀ and₁' hc) (and₂' hc)
@@ -106,12 +168,26 @@ def orReplace (hp : 𝓢 ⊢ p₁ ⟶ p₂) (hq : 𝓢 ⊢ q₁ ⟶ q₂) : 𝓢
   exact orReplace' FiniteContext.id (of hp) (of hq) ;
 lemma or_replace! (hp : 𝓢 ⊢! p₁ ⟶ p₂) (hq : 𝓢 ⊢! q₁ ⟶ q₂) : 𝓢 ⊢! p₁ ⋎ q₁ ⟶ p₂ ⋎ q₂ := ⟨orReplace hp.some hq.some⟩
 
-
 def orReplaceIff (hp : 𝓢 ⊢ p₁ ⟷ p₂) (hq : 𝓢 ⊢ q₁ ⟷ q₂) : 𝓢 ⊢ p₁ ⋎ q₁ ⟷ p₂ ⋎ q₂ := by
   apply iffIntro;
   . exact orReplace (and₁' hp) (and₁' hq);
   . exact orReplace (and₂' hp) (and₂' hq);
 lemma or_replace_iff! (hp : 𝓢 ⊢! p₁ ⟷ p₂) (hq : 𝓢 ⊢! q₁ ⟷ q₂) : 𝓢 ⊢! p₁ ⋎ q₁ ⟷ p₂ ⋎ q₂ := ⟨orReplaceIff hp.some hq.some⟩
+
+lemma or_assoc! : 𝓢 ⊢! p ⋎ (q ⋎ r) ⟷ (p ⋎ q) ⋎ r := by
+  apply iff_intro!;
+  . exact deduct'! $ or_assoc'!.mp id!;
+  . exact deduct'! $ or_assoc'!.mpr id!;
+
+lemma or_replace_right_iff! (d : 𝓢 ⊢! q ⟷ r) : 𝓢 ⊢! p ⋎ q ⟷ p ⋎ r := by
+  apply iff_intro!;
+  . apply or_replace_right!; exact and₁'! d;
+  . apply or_replace_right!; exact and₂'! d;
+
+lemma or_replace_left_iff! (d : 𝓢 ⊢! p ⟷ r) : 𝓢 ⊢! p ⋎ q ⟷ r ⋎ q := by
+  apply iff_intro!;
+  . apply or_replace_left!; exact and₁'! d;
+  . apply or_replace_left!; exact and₂'! d;
 
 
 def andReplaceIff (hp : 𝓢 ⊢ p₁ ⟷ p₂) (hq : 𝓢 ⊢ q₁ ⟷ q₂) : 𝓢 ⊢ p₁ ⋏ q₁ ⟷ p₂ ⋏ q₂ := by
@@ -262,11 +338,15 @@ lemma dn_distribute_imply'! (b : 𝓢 ⊢! ~~(p ⟶ q)) : 𝓢 ⊢! ~~p ⟶ ~~q 
 
 def introFalsumOfAnd' (h : 𝓢 ⊢ p ⋏ ~p) : 𝓢 ⊢ ⊥ := (neg_equiv'.mp $ and₂' h) ⨀ (and₁' h)
 lemma intro_falsum_of_and'! (h : 𝓢 ⊢! p ⋏ ~p) : 𝓢 ⊢! ⊥ := ⟨introFalsumOfAnd' h.some⟩
+/-- Law of contradiction -/
+alias lac'! := intro_falsum_of_and'!
 
 def introFalsumOfAnd : 𝓢 ⊢ p ⋏ ~p ⟶ ⊥ := by
   apply deduct';
   exact introFalsumOfAnd' (p := p) $ FiniteContext.id
 @[simp] lemma intro_bot_of_and! : 𝓢 ⊢! p ⋏ ~p ⟶ ⊥ := ⟨introFalsumOfAnd⟩
+/-- Law of contradiction -/
+alias lac! := intro_bot_of_and!
 
 
 
@@ -362,17 +442,43 @@ def andImplyAndOfImply {p q p' q' : F} (bp : 𝓢 ⊢ p ⟶ p') (bq : 𝓢 ⊢ q
 def andIffAndOfIff {p q p' q' : F} (bp : 𝓢 ⊢ p ⟷ p') (bq : 𝓢 ⊢ q ⟷ q') : 𝓢 ⊢ p ⋏ q ⟷ p' ⋏ q' :=
   iffIntro (andImplyAndOfImply (andLeft bp) (andLeft bq)) (andImplyAndOfImply (andRight bp) (andRight bq))
 
-def conj'IffConj : (Γ : List F) → 𝓢 ⊢ ⋀Γ ⟷ Γ.conj
+
+section Instantinate
+
+instance [HasAxiomDNE 𝓢] : HasAxiomEFQ 𝓢 where
+  efq p := by
+    apply contra₃';
+    exact impTrans'' (and₁' neg_equiv) $ impTrans'' (impSwap' imply₁) (and₂' neg_equiv);
+
+
+-- TODO: Actually this can be computable but it's too slow.
+noncomputable instance [HasAxiomDNE 𝓢] : HasAxiomLEM 𝓢 where
+  lem _ := dneOr $ NotOrOfImply' dni
+
+instance [HasAxiomEFQ 𝓢] [HasAxiomLEM 𝓢] : HasAxiomDNE 𝓢 where
+  dne p := by
+    apply deduct';
+    exact or₃''' (impId _) (by
+      apply deduct;
+      have nnp : [~p, ~~p] ⊢[𝓢] ~p ⟶ ⊥ := neg_equiv'.mp $ FiniteContext.byAxm;
+      have np : [~p, ~~p] ⊢[𝓢] ~p := FiniteContext.byAxm;
+      exact efq' $ nnp ⨀ np;
+    ) $ of lem;;
+
+end Instantinate
+
+
+def conjIffConj : (Γ : List F) → 𝓢 ⊢ ⋀Γ ⟷ Γ.conj
   | []          => iffId ⊤
   | [_]         => iffIntro (deduct' <| andIntro FiniteContext.id verum) and₁
-  | p :: q :: Γ => andIffAndOfIff (iffId p) (conj'IffConj (q :: Γ))
-@[simp] lemma conj'IffConj! : 𝓢 ⊢! ⋀Γ ⟷ Γ.conj := ⟨conj'IffConj Γ⟩
+  | p :: q :: Γ => andIffAndOfIff (iffId p) (conjIffConj (q :: Γ))
+@[simp] lemma conjIffConj! : 𝓢 ⊢! ⋀Γ ⟷ Γ.conj := ⟨conjIffConj Γ⟩
 
 
-lemma implyLeft_conj_eq_conj'! : 𝓢 ⊢! Γ.conj ⟶ p ↔ 𝓢 ⊢! ⋀Γ ⟶ p := replace_imply_left_by_iff'! $ iff_comm'! conj'IffConj!
+lemma implyLeft_conj_eq_conj! : 𝓢 ⊢! Γ.conj ⟶ p ↔ 𝓢 ⊢! ⋀Γ ⟶ p := replace_imply_left_by_iff'! $ iff_comm'! conjIffConj!
 
 
-lemma generalConj'! (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ⟶ p := replace_imply_left_by_iff'! conj'IffConj! |>.mpr (generalConj! h)
+lemma generalConj'! (h : p ∈ Γ) : 𝓢 ⊢! ⋀Γ ⟶ p := replace_imply_left_by_iff'! conjIffConj! |>.mpr (generalConj! h)
 lemma generalConj'₂! (h : p ∈ Γ) (d : 𝓢 ⊢! ⋀Γ) : 𝓢 ⊢! p := (generalConj'! h) ⨀ d
 
 
@@ -390,6 +496,8 @@ lemma emptyPrf! {p : F} : ∅ *⊢[𝓢]! p ↔ 𝓢 ⊢! p := by
 
 end Context
 
+section Conjunction
+
 lemma iff_provable_list_conj {Γ : List F} : (𝓢 ⊢! ⋀Γ) ↔ (∀ p ∈ Γ, 𝓢 ⊢! p) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
@@ -404,82 +512,23 @@ lemma iff_provable_list_conj {Γ : List F} : (𝓢 ⊢! ⋀Γ) ↔ (∀ p ∈ Γ
     . rintro ⟨h₁, h₂⟩;
       exact and₃'! h₁ (ih.mpr h₂);
 
-lemma conj'conj'_subset (h : ∀ p, p ∈ Γ → p ∈ Δ) : 𝓢 ⊢! ⋀Δ ⟶ ⋀Γ := by
+lemma conjconj_subset! (h : ∀ p, p ∈ Γ → p ∈ Δ) : 𝓢 ⊢! ⋀Δ ⟶ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simpa using dhyp! verum!;
+  | hnil => simp;
   | hsingle => simp_all; exact generalConj'! h;
   | hcons p Γ hne ih => simp_all; exact imply_right_and! (generalConj'! h.1) ih;
 
-def implyOrLeft' (h : 𝓢 ⊢ p ⟶ r) : 𝓢 ⊢ p ⟶ (r ⋎ q) := by
-  apply deduct';
-  apply or₁';
-  apply deductInv;
-  exact of h;
-lemma imply_or_left'! (h : 𝓢 ⊢! p ⟶ r) : 𝓢 ⊢! p ⟶ (r ⋎ q) := ⟨implyOrLeft' h.some⟩
-
-def implyOrRight' (h : 𝓢 ⊢ q ⟶ r) : 𝓢 ⊢ q ⟶ (p ⋎ r) := by
-  apply deduct';
-  apply or₂';
-  apply deductInv;
-  exact of h;
-lemma imply_or_right'! (h : 𝓢 ⊢! q ⟶ r) : 𝓢 ⊢! q ⟶ (p ⋎ r) := ⟨implyOrRight' h.some⟩
-
-lemma or_assoc'! : 𝓢 ⊢! p ⋎ (q ⋎ r) ↔ 𝓢 ⊢! (p ⋎ q) ⋎ r := by
-  constructor;
-  . intro h;
-    exact or₃'''!
-      (imply_or_left'! $ imply_or_left'! imp_id!)
-      (by
-        apply provable_iff_provable.mpr;
-        apply deduct_iff.mpr;
-        exact or₃'''! (imply_or_left'! $ imply_or_right'! imp_id!) (imply_or_right'! imp_id!) id!;
-      )
-      h;
-  . intro h;
-    exact or₃'''!
-      (by
-        apply provable_iff_provable.mpr;
-        apply deduct_iff.mpr;
-        exact or₃'''! (imply_or_left'! imp_id!) (imply_or_right'! $ imply_or_left'! imp_id!) id!;
-      )
-      (imply_or_right'! $ imply_or_right'! imp_id!)
-      h;
-
-lemma and_assoc! : 𝓢 ⊢! (p ⋏ q) ⋏ r ⟷ p ⋏ (q ⋏ r) := by
-  apply iff_intro!;
-  . apply FiniteContext.deduct'!;
-    have hp : [(p ⋏ q) ⋏ r] ⊢[𝓢]! p := and₁'! $ and₁'! id!;
-    have hq : [(p ⋏ q) ⋏ r] ⊢[𝓢]! q := and₂'! $ and₁'! id!;
-    have hr : [(p ⋏ q) ⋏ r] ⊢[𝓢]! r := and₂'! id!;
-    exact and₃'! hp (and₃'! hq hr);
-  . apply FiniteContext.deduct'!;
-    have hp : [p ⋏ (q ⋏ r)] ⊢[𝓢]! p := and₁'! id!;
-    have hq : [p ⋏ (q ⋏ r)] ⊢[𝓢]! q := and₁'! $ and₂'! id!;
-    have hr : [p ⋏ (q ⋏ r)] ⊢[𝓢]! r := and₂'! $ and₂'! id!;
-    apply and₃'!;
-    . exact and₃'! hp hq;
-    . exact hr;
-
-lemma cut! (d₁ : 𝓢 ⊢! p₁ ⋏ c ⟶ q₁) (d₂ : 𝓢 ⊢! p₂ ⟶ c ⋎ q₂) : 𝓢 ⊢! p₁ ⋏ p₂ ⟶ q₁ ⋎ q₂ := by
-  apply deduct'!;
-  exact or₃'''! (imply_or_left'! $ of'! (and_imply_iff_imply_imply'!.mp d₁) ⨀ (and₁'! id!)) or₂! (of'! d₂ ⨀ and₂'! id!);
-
-lemma imply_left_and_comm'! (d : 𝓢 ⊢! p ⋏ q ⟶ r) : 𝓢 ⊢! q ⋏ p ⟶ r := imp_trans''! and_comm! d
-
-lemma id_conj'! (he : ∀ g ∈ Γ, g = p) : 𝓢 ⊢! p ⟶ ⋀Γ := by
+lemma id_conj! (he : ∀ g ∈ Γ, g = p) : 𝓢 ⊢! p ⟶ ⋀Γ := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp_all only [conj'_nil, IsEmpty.forall_iff, forall_const]; exact dhyp! $ verum!;
-  | hsingle => simp_all only [List.mem_singleton, forall_eq, conj'_singleton, imp_id!];
   | hcons r Γ h ih =>
-    simp [conj'_cons_nonempty h];
-    simp at he;
-    have ⟨he₁, he₂⟩ := he;
-    subst he₁;
-    exact imply_right_and! imp_id! (ih he₂);
+    simp_all;
+    have ⟨he₁, he₂⟩ := he; subst he₁;
+    exact imply_right_and! imp_id! ih;
+  | _ => simp_all;
 
-lemma replace_imply_left_conj'! (he : ∀ g ∈ Γ, g = p) (hd : 𝓢 ⊢! ⋀Γ ⟶ q) : 𝓢 ⊢! p ⟶ q := imp_trans''! (id_conj'! he) hd
+lemma replace_imply_left_conj! (he : ∀ g ∈ Γ, g = p) (hd : 𝓢 ⊢! ⋀Γ ⟶ q) : 𝓢 ⊢! p ⟶ q := imp_trans''! (id_conj! he) hd
 
-lemma implyLeft_cons_conj'! : 𝓢 ⊢! ⋀(p :: Γ) ⟶ q ↔ 𝓢 ⊢! p ⋏ ⋀Γ ⟶ q := by
+lemma iff_imply_left_cons_conj'! : 𝓢 ⊢! ⋀(p :: Γ) ⟶ q ↔ 𝓢 ⊢! p ⋏ ⋀Γ ⟶ q := by
   induction Γ with
   | nil =>
     simp [and_imply_iff_imply_imply'!];
@@ -488,7 +537,8 @@ lemma implyLeft_cons_conj'! : 𝓢 ⊢! ⋀(p :: Γ) ⟶ q ↔ 𝓢 ⊢! p ⋏ �
     . intro h; exact imp_swap'! h ⨀ verum!;
   | cons q ih => simp;
 
-lemma imply_left_concat_conj'! : 𝓢 ⊢! ⋀(Γ ++ Δ) ⟶ ⋀Γ ⋏ ⋀Δ := by
+@[simp]
+lemma imply_left_concat_conj! : 𝓢 ⊢! ⋀(Γ ++ Δ) ⟶ ⋀Γ ⋏ ⋀Δ := by
   apply FiniteContext.deduct'!;
   have : [⋀(Γ ++ Δ)] ⊢[𝓢]! ⋀(Γ ++ Δ) := id!;
   have d := iff_provable_list_conj.mp this;
@@ -509,7 +559,7 @@ lemma forthback_conj_remove! : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ⟶ ⋀Γ := by
   . subst e; exact and₂'! id!;
   . exact iff_provable_list_conj.mp (and₁'! id!) q (by apply List.mem_remove_iff.mpr; simp_all);
 
-lemma imply_left_remove_conj'! (b : 𝓢 ⊢! ⋀Γ ⟶ q) : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ⟶ q := imp_trans''! forthback_conj_remove! b
+lemma imply_left_remove_conj! (b : 𝓢 ⊢! ⋀Γ ⟶ q) : 𝓢 ⊢! ⋀(Γ.remove p) ⋏ p ⟶ q := imp_trans''! forthback_conj_remove! b
 
 lemma iff_concat_conj'! : 𝓢 ⊢! ⋀(Γ ++ Δ) ↔ 𝓢 ⊢! ⋀Γ ⋏ ⋀Δ := by
   constructor;
@@ -527,55 +577,46 @@ lemma iff_concat_conj'! : 𝓢 ⊢! ⋀(Γ ++ Δ) ↔ 𝓢 ⊢! ⋀Γ ⋏ ⋀Δ 
     . exact (iff_provable_list_conj.mp $ and₁'! h) p hp₁;
     . exact (iff_provable_list_conj.mp $ and₂'! h) p hp₂;
 
+@[simp]
 lemma iff_concat_conj! : 𝓢 ⊢! ⋀(Γ ++ Δ) ⟷ ⋀Γ ⋏ ⋀Δ := by
   apply iff_intro!;
   . apply deduct'!; apply iff_concat_conj'!.mp; exact id!;
   . apply deduct'!; apply iff_concat_conj'!.mpr; exact id!;
 
-lemma or_assoc! : 𝓢 ⊢! p ⋎ (q ⋎ r) ⟷ (p ⋎ q) ⋎ r := by
-  apply iff_intro!;
-  . exact deduct'! $ or_assoc'!.mp id!;
-  . exact deduct'! $ or_assoc'!.mpr id!;
+end Conjunction
 
-lemma or_replace_right_iff! (d : 𝓢 ⊢! q ⟷ r) : 𝓢 ⊢! p ⋎ q ⟷ p ⋎ r := by
-  apply iff_intro!;
-  . apply or_replace_right!; exact and₁'! d;
-  . apply or_replace_right!; exact and₂'! d;
 
-lemma or_replace_left_iff! (d : 𝓢 ⊢! p ⟷ r) : 𝓢 ⊢! p ⋎ q ⟷ r ⋎ q := by
-  apply iff_intro!;
-  . apply or_replace_left!; exact and₁'! d;
-  . apply or_replace_left!; exact and₂'! d;
+section disjunction
 
 lemma iff_concact_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ⟷ ⋁Γ ⋎ ⋁Δ := by
   induction Γ using List.induction_with_singleton generalizing Δ <;> induction Δ using List.induction_with_singleton;
   case hnil.hnil =>
-    simp only [List.append_nil, disj'_nil];
+    simp_all;
     apply iff_intro!;
     . simp;
     . exact or₃''! efq! efq!;
   case hnil.hsingle =>
-    simp only [List.nil_append, disj'_singleton, disj'_nil];
+    simp_all;
     apply iff_intro!;
     . simp;
     . exact or₃''! efq! imp_id!;
   case hsingle.hnil =>
-    simp only [List.singleton_append, disj'_singleton, disj'_nil];
+    simp_all;
     apply iff_intro!;
     . simp;
     . exact or₃''! imp_id! efq!;
   case hcons.hnil =>
-    simp only [List.append_nil, disj'_nil];
+    simp_all;
     apply iff_intro!;
     . simp;
     . exact or₃''! imp_id! efq!;
   case hnil.hcons =>
-    simp only [List.nil_append, disj'_nil];
+    simp_all;
     apply iff_intro!;
     . simp;
     . exact or₃''! efq! imp_id!;
-  case hsingle.hsingle => simp only [List.singleton_append, ne_eq, not_false_eq_true, disj'_cons_nonempty, disj'_singleton, iff_id!];
-  case hsingle.hcons => simp only [List.singleton_append, ne_eq, not_false_eq_true, disj'_cons_nonempty, disj'_singleton, iff_id!];
+  case hsingle.hsingle => simp_all;
+  case hsingle.hcons => simp_all;
   case hcons.hsingle p ps hps ihp q =>
     simp_all;
     apply iff_trans''! (by
@@ -583,12 +624,12 @@ lemma iff_concact_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ⟷ ⋁Γ �
       simpa using @ihp [q];
     ) or_assoc!;
   case hcons.hcons p ps hps ihp q qs hqs ihq =>
-    simp_all only [ne_eq, List.cons_append, List.append_eq_nil, and_self, not_false_eq_true, disj'_cons_nonempty];
-    apply iff_trans''! (by
+    simp_all;
+    exact iff_trans''! (by
       apply or_replace_right_iff!;
       exact iff_trans''! (@ihp (q :: qs)) (by
         apply or_replace_right_iff!;
-        simp [disj'_cons_nonempty hqs];
+        simp_all;
       )
     ) or_assoc!;
 
@@ -597,7 +638,7 @@ lemma iff_concact_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁(Γ ++ Δ) ↔ 𝓢 �
   . intro h; exact (and₁'! iff_concact_disj!) ⨀ h;
   . intro h; exact (and₂'! iff_concact_disj!) ⨀ h;
 
-lemma implyRight_cons_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ⟶ ⋁(q :: Γ) ↔ 𝓢 ⊢! p ⟶ q ⋎ ⋁Γ := by
+lemma implyRight_cons_disj! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ⟶ ⋁(q :: Γ) ↔ 𝓢 ⊢! p ⟶ q ⋎ ⋁Γ := by
   induction Γ with
   | nil =>
     simp;
@@ -607,7 +648,7 @@ lemma implyRight_cons_disj'! [HasAxiomEFQ 𝓢] : 𝓢 ⊢! p ⟶ ⋁(q :: Γ) �
   | cons q ih => simp;
 
 @[simp]
-lemma forthback_disj'_remove [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁Γ ⟶ p ⋎ ⋁(Γ.remove p) := by
+lemma forthback_disj_remove [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁Γ ⟶ p ⋎ ⋁(Γ.remove p) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle q =>
@@ -616,59 +657,28 @@ lemma forthback_disj'_remove [HasAxiomEFQ 𝓢] : 𝓢 ⊢! ⋁Γ ⟶ p ⋎ ⋁(
     . subst_vars; simp;
     . simp [(List.remove_singleton_of_ne h)];
   | hcons q Γ h ih =>
-    simp [(disj'_cons_nonempty h)];
+    simp_all;
     by_cases hpq : q = p;
     . simp_all only [ne_eq, List.remove_cons_self]; exact or₃''! or₁! ih;
     . simp_all [(List.remove_cons_of_ne Γ hpq)];
       by_cases hqΓ : Γ.remove p = [];
       . simp_all;
         exact or₃''! or₂! (imp_trans''! ih $ or_replace_right! efq!);
-      . simp [(disj'_cons_nonempty hqΓ)];
+      . simp_all;
         exact or₃''! (imp_trans''! or₁! or₂!) (imp_trans''! ih (or_replace_right! or₂!));
 
 lemma disj_allsame! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) : 𝓢 ⊢! ⋁Γ ⟶ p := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp_all [disj'_nil, efq!];
-  | hsingle => simp_all [List.mem_singleton, disj'_singleton, imp_id!];
   | hcons q Δ hΔ ih =>
-    simp [disj'_cons_nonempty hΔ];
-    simp at hd;
-    have ⟨hd₁, hd₂⟩ := hd;
-    subst hd₁;
+    simp_all;
+    have ⟨hd₁, hd₂⟩ := hd; subst hd₁;
     apply provable_iff_provable.mpr;
     apply deduct_iff.mpr;
-    exact or₃'''! (by simp) (weakening! (by simp) $ provable_iff_provable.mp $ ih hd₂) id!
+    exact or₃'''! (by simp) (weakening! (by simp) $ provable_iff_provable.mp $ ih) id!
+  | _ => simp_all;
 
 lemma disj_allsame'! [HasAxiomEFQ 𝓢] (hd : ∀ q ∈ Γ, q = p) (h : 𝓢 ⊢! ⋁Γ) : 𝓢 ⊢! p := (disj_allsame! hd) ⨀ h
 
-instance [HasAxiomDNE 𝓢] : HasAxiomEFQ 𝓢 where
-  efq p := by
-    apply contra₃';
-    exact impTrans'' (and₁' neg_equiv) $ impTrans'' (impSwap' imply₁) (and₂' neg_equiv);
-
-def dneOr [HasAxiomDNE 𝓢] (d : 𝓢 ⊢ ~~p ⋎ ~~q) : 𝓢 ⊢ p ⋎ q := or₃''' (impTrans'' dne or₁) (impTrans'' dne or₂) d
-
--- TODO: Actually this can be computable but it's too slow.
-noncomputable instance [HasAxiomDNE 𝓢] : HasAxiomLEM 𝓢 where
-  lem _ := dneOr $ NotOrOfImply' dni
-
-instance [HasAxiomEFQ 𝓢] [HasAxiomLEM 𝓢] : HasAxiomDNE 𝓢 where
-  dne p := by
-    apply deduct';
-    exact or₃''' (impId _) (by
-      apply deduct;
-      have nnp : [~p, ~~p] ⊢[𝓢] ~p ⟶ ⊥ := neg_equiv'.mp $ FiniteContext.byAxm;
-      have np : [~p, ~~p] ⊢[𝓢] ~p := FiniteContext.byAxm;
-      exact efq' $ nnp ⨀ np;
-    ) $ of lem;;
-
-def noBoth : 𝓢 ⊢ (p ⋏ ~p) ⟶ ⊥ := by
-  apply deduct';
-  have h : [p ⋏ ~p] ⊢[𝓢] p ⋏ ~p := FiniteContext.byAxm;
-  have h₁ : [p ⋏ ~p] ⊢[𝓢] p := and₁' $ h;
-  have h₂ : [p ⋏ ~p] ⊢[𝓢] p ⟶ ⊥ :=  neg_equiv'.mp $ and₂' h;
-  exact h₂ ⨀ h₁;
-lemma no_both! : 𝓢 ⊢! (p ⋏ ~p) ⟶ ⊥ := ⟨noBoth⟩
-
+end disjunction
 
 end LO.System

--- a/Logic/Logic/LogicSymbol.lean
+++ b/Logic/Logic/LogicSymbol.lean
@@ -459,7 +459,7 @@ def conj : {n : ℕ} → (Fin n → α) → α
 lemma hom_conj [FunLike F α β] [LogicalConnective.HomClass F α β] (f : F) (v : Fin n → α) : f (conj v) = conj (f ∘ v) := by
   induction' n with n ih <;> simp[*, conj]
 
-lemma hom_conj' [FunLike F α β] [LogicalConnective.HomClass F α β] (f : F) (v : Fin n → α) : f (conj v) = conj fun i => f (v i) := hom_conj f v
+lemma hom_conj₂ [FunLike F α β] [LogicalConnective.HomClass F α β] (f : F) (v : Fin n → α) : f (conj v) = conj fun i => f (v i) := hom_conj f v
 
 end And
 
@@ -507,43 +507,43 @@ section
 variable {F : Type u} [LogicalConnective F]
 variable {p q : F}
 
-/-- Remark: `[p].conj' = p ≠ p ⋏ ⊤ = [p].conj` -/
-def conj' : List F → F
+/-- Remark: `[p].conj₂ = p ≠ p ⋏ ⊤ = [p].conj` -/
+def conj₂ : List F → F
 | [] => ⊤
 | [p] => p
-| p :: q :: rs => p ⋏ (q :: rs).conj'
+| p :: q :: rs => p ⋏ (q :: rs).conj₂
 
-prefix:80 "⋀" => List.conj'
+prefix:80 "⋀" => List.conj₂
 
-@[simp] lemma conj'_nil : ⋀[] = (⊤ : F) := rfl
+@[simp] lemma conj₂_nil : ⋀[] = (⊤ : F) := rfl
 
-@[simp] lemma conj'_singleton : ⋀[p] = p := rfl
+@[simp] lemma conj₂_singleton : ⋀[p] = p := rfl
 
-@[simp] lemma conj'_doubleton : ⋀[p, q] = p ⋏ q := rfl
+@[simp] lemma conj₂_doubleton : ⋀[p, q] = p ⋏ q := rfl
 
-@[simp] lemma conj'_cons_nonempty {a : F} {as : List F} (h : as ≠ []) : ⋀(a :: as) = a ⋏ ⋀as := by
+@[simp] lemma conj₂_cons_nonempty {a : F} {as : List F} (h : as ≠ [] := by assumption) : ⋀(a :: as) = a ⋏ ⋀as := by
   cases as with
   | nil => contradiction;
-  | cons q rs => simp [List.conj']
+  | cons q rs => simp [List.conj₂]
 
 /-- Remark: `[p].disj = p ≠ p ⋎ ⊥ = [p].disj` -/
-def disj' : List F → F
+def disj₂ : List F → F
 | [] => ⊥
 | [p] => p
-| p :: q :: rs => p ⋎ (q :: rs).disj'
+| p :: q :: rs => p ⋎ (q :: rs).disj₂
 
-prefix:80 "⋁" => disj'
+prefix:80 "⋁" => disj₂
 
-@[simp] lemma disj'_nil : ⋁[] = (⊥ : F) := rfl
+@[simp] lemma disj₂_nil : ⋁[] = (⊥ : F) := rfl
 
-@[simp] lemma disj'_singleton : ⋁[p] = p := rfl
+@[simp] lemma disj₂_singleton : ⋁[p] = p := rfl
 
-@[simp] lemma disj'_doubleton : ⋁[p, q] = p ⋎ q := rfl
+@[simp] lemma disj₂_doubleton : ⋁[p, q] = p ⋎ q := rfl
 
-@[simp] lemma disj'_cons_nonempty {a : F} {as : List F} (h : as ≠ []) : ⋁(a :: as) = a ⋎ ⋁as := by
+@[simp] lemma disj₂_cons_nonempty {a : F} {as : List F} (h : as ≠ [] := by assumption) : ⋁(a :: as) = a ⋎ ⋁as := by
   cases as with
   | nil => contradiction;
-  | cons q rs => simp [disj']
+  | cons q rs => simp [disj₂]
 
 lemma induction_with_singleton
   {motive : List F → Prop}

--- a/Logic/Logic/LogicSymbol.lean
+++ b/Logic/Logic/LogicSymbol.lean
@@ -513,13 +513,15 @@ def conj' : List F → F
 | [p] => p
 | p :: q :: rs => p ⋏ (q :: rs).conj'
 
-@[simp] lemma conj'_nil : conj' (F := F) [] = ⊤ := rfl
+prefix:80 "⋀" => List.conj'
 
-@[simp] lemma conj'_singleton : [p].conj' = p := rfl
+@[simp] lemma conj'_nil : ⋀[] = (⊤ : F) := rfl
 
-@[simp] lemma conj'_doubleton : [p, q].conj' = p ⋏ q := rfl
+@[simp] lemma conj'_singleton : ⋀[p] = p := rfl
 
-@[simp] lemma conj'_cons_nonempty {a : F} {as : List F} (h : as ≠ []) : (a :: as).conj' = a ⋏ as.conj' := by
+@[simp] lemma conj'_doubleton : ⋀[p, q] = p ⋏ q := rfl
+
+@[simp] lemma conj'_cons_nonempty {a : F} {as : List F} (h : as ≠ []) : ⋀(a :: as) = a ⋏ ⋀as := by
   cases as with
   | nil => contradiction;
   | cons q rs => simp [List.conj']
@@ -530,16 +532,18 @@ def disj' : List F → F
 | [p] => p
 | p :: q :: rs => p ⋎ (q :: rs).disj'
 
-@[simp] lemma disj'_nil : disj' (F := F) [] = ⊥ := rfl
+prefix:80 "⋁" => disj'
 
-@[simp] lemma disj'_singleton : [p].disj' = p := rfl
+@[simp] lemma disj'_nil : ⋁[] = (⊥ : F) := rfl
 
-@[simp] lemma disj'_doubleton : [p, q].disj' = p ⋎ q := rfl
+@[simp] lemma disj'_singleton : ⋁[p] = p := rfl
 
-@[simp] lemma disj'_cons_nonempty {a : F} {as : List F} (h : as ≠ []) : (a :: as).disj' = a ⋎ as.disj' := by
+@[simp] lemma disj'_doubleton : ⋁[p, q] = p ⋎ q := rfl
+
+@[simp] lemma disj'_cons_nonempty {a : F} {as : List F} (h : as ≠ []) : ⋁(a :: as) = a ⋎ ⋁as := by
   cases as with
   | nil => contradiction;
-  | cons q rs => simp [List.disj']
+  | cons q rs => simp [disj']
 
 lemma induction_with_singleton
   {motive : List F → Prop}
@@ -565,7 +569,7 @@ section
 variable [LogicalConnective α] [DecidableEq α]
 
 noncomputable def conj (s : Finset α) : α := s.toList.conj
-prefix:80 "⋀" => Finset.conj
+-- prefix:80 "⋀" => Finset.conj
 
 lemma map_conj [FunLike F α Prop] [LogicalConnective.HomClass F α Prop] (f : F) (s : Finset α) : f s.conj ↔ ∀ a ∈ s, f a := by
   simpa using List.map_conj f s.toList
@@ -583,7 +587,7 @@ lemma map_conj_union [FunLike F α Prop] [LogicalConnective.HomClass F α Prop] 
     cases ha <;> simp_all;
 
 noncomputable def disj (s : Finset α) : α := s.toList.disj
-prefix:80 "⋁" => Finset.disj
+-- prefix:80 "⋁" => Finset.disj
 
 lemma map_disj [FunLike F α Prop] [LogicalConnective.HomClass F α Prop] (f : F) (s : Finset α) : f s.disj ↔ ∃ a ∈ s, f a := by
   simpa using List.map_disj f s.toList

--- a/Logic/Modal/Standard/ConsistentTheory.lean
+++ b/Logic/Modal/Standard/ConsistentTheory.lean
@@ -6,7 +6,7 @@ variable {α : Type*} [DecidableEq α] [Inhabited α]
 
 open System
 
-def Theory.Consistent (𝓓 : DeductionParameter α) (T : Theory α) := ∀ {Γ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → 𝓓 ⊬! Γ.conj' ⟶ ⊥
+def Theory.Consistent (𝓓 : DeductionParameter α) (T : Theory α) := ∀ {Γ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → 𝓓 ⊬! ⋀Γ ⟶ ⊥
 notation:max "(" 𝓓 ")-Consistent " T:90 => Theory.Consistent 𝓓 T
 
 namespace Theory
@@ -20,7 +20,7 @@ lemma self_Consistent [h : System.Consistent 𝓓] : (𝓓)-Consistent Ax(𝓓) 
   have : 𝓓 ⊢! q := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => Deduction.maxm! $ hΓ _ h);
   contradiction;
 
-lemma def_not_Consistent : ¬(𝓓)-Consistent T ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! Γ.conj' ⟶ ⊥ := by simp [Consistent];
+lemma def_not_Consistent : ¬(𝓓)-Consistent T ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! ⋀Γ ⟶ ⊥ := by simp [Consistent];
 
 lemma union_Consistent : (𝓓)-Consistent (T₁ ∪ T₂) → (𝓓)-Consistent T₁ ∧ (𝓓)-Consistent T₂ := by
   simp only [Consistent];
@@ -34,11 +34,11 @@ lemma union_not_Consistent : ¬(𝓓)-Consistent T₁ ∨ ¬(𝓓)-Consistent T�
   push_neg;
   exact union_Consistent;
 
-lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List (Formula α)}, (∀ q ∈ Γ, q ∈ T) → 𝓓 ⊬! p ⋏ Γ.conj' ⟶ ⊥ := by
+lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List (Formula α)}, (∀ q ∈ Γ, q ∈ T) → 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⊥ := by
   constructor;
   . intro h Γ hΓ;
     by_contra hC;
-    have : 𝓓 ⊬! p ⋏ List.conj' Γ ⟶ ⊥ := implyLeft_cons_conj'!.not.mp $ @h (p :: Γ) (by
+    have : 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⊥ := implyLeft_cons_conj'!.not.mp $ @h (p :: Γ) (by
       rintro q hq;
       simp at hq;
       cases hq with
@@ -58,7 +58,7 @@ lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List 
     have := imp_trans''! and_comm! $ imply_left_remove_conj'! (p := p) hC;
     contradiction;
 
-lemma iff_insert_Inconsistent : ¬(𝓓)-Consistent (insert p T) ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! p ⋏ Γ.conj' ⟶ ⊥ := by
+lemma iff_insert_Inconsistent : ¬(𝓓)-Consistent (insert p T) ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! p ⋏ ⋀Γ ⟶ ⊥ := by
   constructor;
   . contrapose; push_neg; apply iff_insert_Consistent.mpr;
   . contrapose; push_neg; apply iff_insert_Consistent.mp;
@@ -126,15 +126,15 @@ lemma unprovable_either : ¬(T *⊢[𝓓]! p ∧ T *⊢[𝓓]! ~p) := by
   have ⟨hC₁, hC₂⟩ := hC;
   have : T *⊢[𝓓]! ⊥ := neg_mdp! hC₂ hC₁;
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp this;
-  have : 𝓓 ⊬! List.conj' Γ ⟶ ⊥ := hConsis hΓ₁;
-  have : 𝓓 ⊢! List.conj' Γ ⟶ ⊥ := FiniteContext.toₛ! hΓ₂;
+  have : 𝓓 ⊬! ⋀Γ ⟶ ⊥ := hConsis hΓ₁;
+  have : 𝓓 ⊢! ⋀Γ ⟶ ⊥ := FiniteContext.toₛ! hΓ₂;
   contradiction;
 
 lemma not_provable_falsum : T *⊬[𝓓]! ⊥ := by
   by_contra hC;
   obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp $ hC;
-  have : 𝓓 ⊬! List.conj' Γ ⟶ ⊥ := hConsis hΓ₁;
-  have : 𝓓 ⊢! List.conj' Γ ⟶ ⊥ := hΓ₂;
+  have : 𝓓 ⊬! ⋀Γ ⟶ ⊥ := hConsis hΓ₁;
+  have : 𝓓 ⊢! ⋀Γ ⟶ ⊥ := hΓ₂;
   contradiction;
 
 lemma not_mem_falsum_of_Consistent : ⊥ ∉ T := by
@@ -150,8 +150,8 @@ lemma either_consistent (p) : (𝓓)-Consistent (insert p T) ∨ (𝓓)-Consiste
 
   replace hΓ₂ := neg_equiv'!.mpr hΓ₂;
   replace hΔ₂ := neg_equiv'!.mpr hΔ₂;
-  have : 𝓓 ⊢! Γ.conj' ⋏ Δ.conj' ⟶ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
-  have : 𝓓 ⊬! Γ.conj' ⋏ Δ.conj' ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj'! (hConsis (by
+  have : 𝓓 ⊢! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
+  have : 𝓓 ⊬! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj'! (hConsis (by
     simp;
     intro q hq;
     rcases hq with hΓ | hΔ
@@ -190,12 +190,12 @@ protected alias lindenbaum := exists_maximal_Consistent_theory
 
 open Classical in
 lemma intro_union_Consistent
-  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ p ∈ Γ₁, p ∈ T₁) → (∀ p ∈ Γ₂, p ∈ T₂) → 𝓓 ⊬! Γ₁.conj' ⋏ Γ₂.conj' ⟶ ⊥) : (𝓓)-Consistent (T₁ ∪ T₂) := by
+  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ p ∈ Γ₁, p ∈ T₁) → (∀ p ∈ Γ₂, p ∈ T₂) → 𝓓 ⊬! ⋀Γ₁ ⋏ ⋀Γ₂ ⟶ ⊥) : (𝓓)-Consistent (T₁ ∪ T₂) := by
   intro Δ hΔ;
   simp at hΔ;
   let Δ₁ := (Δ.filter (· ∈ T₁));
   let Δ₂ := (Δ.filter (· ∈ T₂));
-  have : 𝓓 ⊬! Δ₁.conj' ⋏ Δ₂.conj' ⟶ ⊥ := @h Δ₁ Δ₂ (by intro _ h; simpa using List.of_mem_filter h) (by intro _ h; simpa using List.of_mem_filter h);
+  have : 𝓓 ⊬! ⋀Δ₁ ⋏ ⋀Δ₂ ⟶ ⊥ := @h Δ₁ Δ₂ (by intro _ h; simpa using List.of_mem_filter h) (by intro _ h; simpa using List.of_mem_filter h);
   exact unprovable_imp_trans''! (by
     apply FiniteContext.deduct'!;
     apply iff_provable_list_conj.mpr;
@@ -401,11 +401,11 @@ lemma iff_mem_multibox : (□^[n]p ∈ Ω.theory) ↔ (∀ {Ω' : (𝓓)-MCT}, (
       apply unprovable_iff_insert_neg_Consistent.mp;
       by_contra hC;
       obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp hC;
-      have : 𝓓 ⊢! □^[n]Γ.conj' ⟶ □^[n]p := imply_multibox_distribute'! hΓ₂;
-      have : 𝓓 ⊬! □^[n]Γ.conj' ⟶ □^[n]p := by
+      have : 𝓓 ⊢! □^[n]⋀Γ ⟶ □^[n]p := imply_multibox_distribute'! hΓ₂;
+      have : 𝓓 ⊬! □^[n]⋀Γ ⟶ □^[n]p := by
         have := Context.provable_iff.not.mp $ membership_iff.not.mp hp;
         push_neg at this;
-        have : 𝓓 ⊬! (□'^[n]Γ : List (Formula α)).conj' ⟶ □^[n]p := FiniteContext.provable_iff.not.mp $ this (□'^[n]Γ) (by
+        have : 𝓓 ⊬! ⋀□'^[n]Γ ⟶ □^[n]p := FiniteContext.provable_iff.not.mp $ this (□'^[n]Γ) (by
           intro q hq;
           obtain ⟨r, hr₁, hr₂⟩ := by simpa using hq;
           subst hr₂;
@@ -496,9 +496,9 @@ lemma multibox_multidia : (∀ {p : Formula α}, (□^[n]p ∈ Ω₁.theory → 
 
 variable {Γ : List (Formula α)}
 
-lemma iff_mem_conj' : (Γ.conj' ∈ Ω.theory) ↔ (∀ p ∈ Γ, p ∈ Ω.theory) := by simp [membership_iff, iff_provable_list_conj];
+lemma iff_mem_conj' : (⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, p ∈ Ω.theory) := by simp [membership_iff, iff_provable_list_conj];
 
-lemma iff_mem_multibox_conj' : (□^[n]Γ.conj' ∈ Ω.theory) ↔ (∀ p ∈ Γ, □^[n]p ∈ Ω.theory) := by
+lemma iff_mem_multibox_conj' : (□^[n]⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □^[n]p ∈ Ω.theory) := by
   simp only [iff_mem_multibox, iff_mem_conj'];
   constructor;
   . intro h p hp Ω' hΩ';
@@ -506,7 +506,7 @@ lemma iff_mem_multibox_conj' : (□^[n]Γ.conj' ∈ Ω.theory) ↔ (∀ p ∈ Γ
   . intro h Ω' hΩ' p hp;
     exact @h p hp Ω' hΩ';
 
-lemma iff_mem_box_conj' : (□Γ.conj' ∈ Ω.theory) ↔ (∀ p ∈ Γ, □p ∈ Ω.theory) := iff_mem_multibox_conj' (n := 1)
+lemma iff_mem_box_conj' : (□⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □p ∈ Ω.theory) := iff_mem_multibox_conj' (n := 1)
 
 end Normal
 

--- a/Logic/Modal/Standard/ConsistentTheory.lean
+++ b/Logic/Modal/Standard/ConsistentTheory.lean
@@ -3,42 +3,61 @@ import Logic.Modal.Standard.Deduction
 namespace LO.Modal.Standard
 
 variable {α : Type*} [DecidableEq α] [Inhabited α]
+variable {Λ : DeductionParameter α} [Λ_consis : System.Consistent Λ]
 
 open System
 
-def Theory.Consistent (𝓓 : DeductionParameter α) (T : Theory α) := ∀ {Γ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → 𝓓 ⊬! ⋀Γ ⟶ ⊥
-notation:max "(" 𝓓 ")-Consistent " T:90 => Theory.Consistent 𝓓 T
+abbrev Theory.Consistent (Λ : DeductionParameter α) (T : Theory α) := T *⊬[Λ]! ⊥
+notation:max "(" Λ ")-Consistent " T:90 => Theory.Consistent Λ T
+
+abbrev Theory.Inconsistent (Λ : DeductionParameter α) (T : Theory α) := ¬(T.Consistent Λ)
 
 namespace Theory
 
-variable {𝓓 : DeductionParameter α} {T : Theory α}
+variable {T : Theory α}
 
-lemma self_Consistent [h : System.Consistent 𝓓] : (𝓓)-Consistent Ax(𝓓) := by
+lemma def_consistent : (Λ)-Consistent T ↔ ∀ (Γ : List (Formula α)), (∀ q ∈ Γ, q ∈ T) → Γ ⊬[Λ]! ⊥ := by
+  constructor;
+  . intro h;
+    simpa using Context.provable_iff.not.mp h;
+  . intro h;
+    apply Context.provable_iff.not.mpr; push_neg;
+    assumption;
+
+lemma def_inconsistent : ¬(Λ)-Consistent T ↔ ∃ (Γ : List (Formula α)), (∀ q ∈ Γ, q ∈ T) ∧ Γ ⊢[Λ]! ⊥ := by
+  simp only [def_consistent]; push_neg; tauto;
+
+@[simp]
+lemma self_consistent : (Λ)-Consistent Ax(Λ) := by
+  obtain ⟨q, hq⟩ := Λ_consis.exists_unprovable;
+  apply def_consistent.mpr;
   intro Γ hΓ;
-  obtain ⟨q, hq⟩ := h.exists_unprovable;
   by_contra hC;
-  have : 𝓓 ⊢! q := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => Deduction.maxm! $ hΓ _ h);
+  have : Λ ⊢! q := imp_trans''! hC efq! ⨀ (iff_provable_list_conj.mpr $ λ _ h => Deduction.maxm! $ hΓ _ h);
   contradiction;
 
-lemma def_not_Consistent : ¬(𝓓)-Consistent T ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! ⋀Γ ⟶ ⊥ := by simp [Consistent];
+lemma emptyset_consistent : (Λ)-Consistent ∅ := by
+  obtain ⟨f, hf⟩ := Λ_consis.exists_unprovable;
+  apply def_consistent.mpr;
+  intro Γ hΓ; by_contra hC;
+  replace hΓ := List.nil_iff.mpr hΓ; subst hΓ;
+  have : Λ ⊢! f := efq'! $ hC ⨀ verum!;
+  contradiction;
 
-lemma union_Consistent : (𝓓)-Consistent (T₁ ∪ T₂) → (𝓓)-Consistent T₁ ∧ (𝓓)-Consistent T₂ := by
-  simp only [Consistent];
+lemma union_consistent : (Λ)-Consistent (T₁ ∪ T₂) → (Λ)-Consistent T₁ ∧ (Λ)-Consistent T₂ := by
   intro h;
-  constructor;
-  . intro Γ hΓ; exact h (by intro p hp; simp; left; exact hΓ p hp);
-  . intro Γ hΓ; exact h (by intro p hp; simp; right; exact hΓ p hp);
+  replace h := def_consistent.mp h;
+  constructor <;> { apply def_consistent.mpr; intro Γ hΓ; exact h Γ (by simp_all); }
 
-lemma union_not_Consistent : ¬(𝓓)-Consistent T₁ ∨ ¬(𝓓)-Consistent T₂ → ¬(𝓓)-Consistent (T₁ ∪ T₂) := by
-  contrapose;
-  push_neg;
-  exact union_Consistent;
+lemma union_not_consistent : ¬(Λ)-Consistent T₁ ∨ ¬(Λ)-Consistent T₂ → ¬(Λ)-Consistent (T₁ ∪ T₂) := by
+  contrapose; push_neg;
+  exact union_consistent;
 
-lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List (Formula α)}, (∀ q ∈ Γ, q ∈ T) → 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⊥ := by
+lemma iff_insert_consistent : (Λ)-Consistent (insert p T) ↔ ∀ {Γ : List (Formula α)}, (∀ q ∈ Γ, q ∈ T) → Λ ⊬! p ⋏ ⋀Γ ⟶ ⊥ := by
   constructor;
   . intro h Γ hΓ;
     by_contra hC;
-    have : 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⊥ := iff_imply_left_cons_conj'!.not.mp $ @h (p :: Γ) (by
+    have : Λ ⊬! p ⋏ ⋀Γ ⟶ ⊥ := iff_imply_left_cons_conj'!.not.mp $ (def_consistent.mp h) (p :: Γ) (by
       rintro q hq;
       simp at hq;
       cases hq with
@@ -46,8 +65,10 @@ lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List 
       | inr h => simp; right; exact hΓ q h;
     );
     contradiction;
-  . intro h Γ hΓ;
-    have := @h (Γ.remove p) (by
+  . intro h;
+    apply def_consistent.mpr;
+    intro Γ hΓ;
+    have  : Λ ⊬! p ⋏ ⋀List.remove p Γ ⟶ ⊥ := @h (Γ.remove p) (by
       intro q hq;
       have := by simpa using hΓ q $ List.mem_of_mem_remove hq;
       cases this with
@@ -55,18 +76,19 @@ lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List 
       | inr h => assumption;
     );
     by_contra hC;
-    have := imp_trans''! and_comm! $ imply_left_remove_conj! (p := p) hC;
+    have := FiniteContext.provable_iff.mp hC;
+    have := imp_trans''! and_comm! $ imply_left_remove_conj! (p := p) $ FiniteContext.provable_iff.mp hC;
     contradiction;
 
-lemma iff_insert_Inconsistent : ¬(𝓓)-Consistent (insert p T) ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! p ⋏ ⋀Γ ⟶ ⊥ := by
+lemma iff_insert_inconsistent : ¬(insert p T).Consistent Λ ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ Λ ⊢! p ⋏ ⋀Γ ⟶ ⊥ := by
   constructor;
-  . contrapose; push_neg; apply iff_insert_Consistent.mpr;
-  . contrapose; push_neg; apply iff_insert_Consistent.mp;
+  . contrapose; push_neg; apply iff_insert_consistent.mpr;
+  . contrapose; push_neg; apply iff_insert_consistent.mp;
 
-lemma provable_iff_insert_neg_not_Consistent : T *⊢[𝓓]! p ↔ ¬(𝓓)-Consistent (insert (~p) T) := by
+lemma provable_iff_insert_neg_not_consistent : T *⊢[Λ]! p ↔ ¬(Λ)-Consistent (insert (~p) T) := by
   constructor;
   . intro h;
-    apply iff_insert_Inconsistent.mpr;
+    apply iff_insert_inconsistent.mpr;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
     existsi Γ;
     constructor;
@@ -76,28 +98,26 @@ lemma provable_iff_insert_neg_not_Consistent : T *⊢[𝓓]! p ↔ ¬(𝓓)-Cons
       exact neg_equiv'!.mp $ dni'! hΓ₂;
   . intro h;
     apply Context.provable_iff.mpr;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_Inconsistent.mp h;
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp h;
     existsi Γ;
     constructor;
     . exact hΓ₁;
-    . have : Γ ⊢[𝓓]! ~p ⟶ ⊥ := imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
+    . have : Γ ⊢[Λ]! ~p ⟶ ⊥ := imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
       exact dne'! $ neg_equiv'!.mpr this;
 
-lemma unprovable_iff_insert_neg_Consistent : T *⊬[𝓓]! p ↔ (𝓓)-Consistent (insert (~p) T) := by
-  constructor;
-  . contrapose; simp [not_not]; apply provable_iff_insert_neg_not_Consistent.mpr;
-  . contrapose; simp [not_not]; apply provable_iff_insert_neg_not_Consistent.mp;
+lemma unprovable_iff_insert_neg_consistent : T *⊬[Λ]! p ↔ (Λ)-Consistent (insert (~p) T) := by
+  simpa [not_not] using provable_iff_insert_neg_not_consistent.not;
 
-lemma unprovable_iff_singleton_neg_Consistent : 𝓓 ⊬! p ↔ (𝓓)-Consistent {~p} := by
+lemma unprovable_iff_singleton_neg_consistent : Λ ⊬! p ↔ (Λ)-Consistent {~p} := by
   have e : insert (~p) ∅ = ({~p} : Theory α) := by aesop;
-  have H := unprovable_iff_insert_neg_Consistent (𝓓 := 𝓓) (T := ∅) (p := p);
+  have H := unprovable_iff_insert_neg_consistent (Λ := Λ) (T := ∅) (p := p);
   rw [e] at H;
   exact Iff.trans Context.emptyPrf!.symm.not H;
 
-lemma neg_provable_iff_insert_not_Consistent : T *⊢[𝓓]! ~p ↔ ¬(𝓓)-Consistent (insert (p) T) := by
+lemma neg_provable_iff_insert_not_consistent : T *⊢[Λ]! ~p ↔ ¬(Λ)-Consistent (insert (p) T) := by
   constructor;
   . intro h;
-    apply iff_insert_Inconsistent.mpr;
+    apply iff_insert_inconsistent.mpr;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp h;
     existsi Γ;
     constructor;
@@ -107,95 +127,96 @@ lemma neg_provable_iff_insert_not_Consistent : T *⊢[𝓓]! ~p ↔ ¬(𝓓)-Con
       exact neg_equiv'!.mp hΓ₂;
   . intro h;
     apply Context.provable_iff.mpr;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_Inconsistent.mp h;
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp h;
     existsi Γ;
     constructor;
     . exact hΓ₁;
     . apply neg_equiv'!.mpr;
       exact imp_swap'! $ and_imply_iff_imply_imply'!.mp hΓ₂;
 
-lemma neg_unprovable_iff_insert_Consistent : T *⊬[𝓓]! ~p ↔ (𝓓)-Consistent (insert (p) T) := by
-  constructor;
-  . contrapose; simp [not_not]; apply neg_provable_iff_insert_not_Consistent.mpr;
-  . contrapose; simp [not_not]; apply neg_provable_iff_insert_not_Consistent.mp;
+lemma neg_unprovable_iff_insert_consistent : T *⊬[Λ]! ~p ↔ (Λ)-Consistent (insert (p) T) := by
+  simpa [not_not] using neg_provable_iff_insert_not_consistent.not;
 
-variable (hConsis : (𝓓)-Consistent T)
+variable (T_consis : (Λ)-Consistent T)
 
-lemma unprovable_either : ¬(T *⊢[𝓓]! p ∧ T *⊢[𝓓]! ~p) := by
+lemma unprovable_falsum : T *⊬[Λ]! ⊥ := by
+  by_contra hC;
+  obtain ⟨Γ, hΓ₁, _⟩ := Context.provable_iff.mp $ hC;
+  have : Γ ⊬[Λ]! ⊥ := (def_consistent.mp T_consis) _ hΓ₁;
+  contradiction;
+
+lemma unprovable_either : ¬(T *⊢[Λ]! p ∧ T *⊢[Λ]! ~p) := by
   by_contra hC;
   have ⟨hC₁, hC₂⟩ := hC;
-  have : T *⊢[𝓓]! ⊥ := neg_mdp! hC₂ hC₁;
-  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp this;
-  have : 𝓓 ⊬! ⋀Γ ⟶ ⊥ := hConsis hΓ₁;
-  have : 𝓓 ⊢! ⋀Γ ⟶ ⊥ := FiniteContext.toₛ! hΓ₂;
+  have : T *⊢[Λ]! ⊥ := neg_mdp! hC₂ hC₁;
+  have : T *⊬[Λ]! ⊥ := unprovable_falsum T_consis;
   contradiction;
 
-lemma not_provable_falsum : T *⊬[𝓓]! ⊥ := by
+lemma not_mem_falsum_of_consistent : ⊥ ∉ T := by
   by_contra hC;
-  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp $ hC;
-  have : 𝓓 ⊬! ⋀Γ ⟶ ⊥ := hConsis hΓ₁;
-  have : 𝓓 ⊢! ⋀Γ ⟶ ⊥ := hΓ₂;
+  have : Λ ⊬! ⊥ ⟶ ⊥ := (def_consistent.mp T_consis) [⊥] (by simpa);
+  have : Λ ⊢! ⊥ ⟶ ⊥ := efq!;
   contradiction;
 
-lemma not_mem_falsum_of_Consistent : ⊥ ∉ T := by
+lemma not_singleton_consistent [Λ.HasNecessitation] (h : ~(□p) ∈ T) : (Λ)-Consistent {~p} := by
+  apply def_consistent.mpr;
+  intro Γ hΓ;
+  simp only [Set.mem_singleton_iff] at hΓ;
   by_contra hC;
-  have : 𝓓 ⊬! ⊥ ⟶ ⊥ := hConsis (Γ := [⊥]) (by simpa);
-  have : 𝓓 ⊢! ⊥ ⟶ ⊥ := efq!;
+  have : Λ ⊢! ~(□p) ⟶ ⊥ := neg_equiv'!.mp $ dni'! $ nec! $ dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
+  have : Λ ⊬! ~(□p) ⟶ ⊥ := def_consistent.mp T_consis (Γ := [~(□p)]) (by aesop)
   contradiction;
 
-lemma either_consistent (p) : (𝓓)-Consistent (insert p T) ∨ (𝓓)-Consistent (insert (~p) T) := by
+lemma either_consistent (p) : (Λ)-Consistent (insert p T) ∨ (Λ)-Consistent (insert (~p) T) := by
   by_contra hC; push_neg at hC;
-  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_Inconsistent.mp hC.1;
-  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_Inconsistent.mp hC.2;
+  obtain ⟨Γ, hΓ₁, hΓ₂⟩ := iff_insert_inconsistent.mp hC.1;
+  obtain ⟨Δ, hΔ₁, hΔ₂⟩ := iff_insert_inconsistent.mp hC.2;
 
   replace hΓ₂ := neg_equiv'!.mpr hΓ₂;
   replace hΔ₂ := neg_equiv'!.mpr hΔ₂;
-  have : 𝓓 ⊢! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
-  have : 𝓓 ⊬! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj! (hConsis (by
+  have : Λ ⊢! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
+  have : Λ ⊬! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj! $ def_consistent.mp T_consis (Γ ++ Δ) $ by
     simp;
-    intro q hq;
-    rcases hq with hΓ | hΔ
-    . exact hΓ₁ _ hΓ;
-    . exact hΔ₁ _ hΔ;
-  ));
+    rintro q (hqΓ | hqΔ);
+    . exact hΓ₁ q hqΓ;
+    . exact hΔ₁ q hqΔ;
   contradiction;
 
-lemma exists_maximal_Consistent_theory
-  : ∃ Z, (𝓓)-Consistent Z ∧ T ⊆ Z ∧ ∀ U, (𝓓)-Consistent U → Z ⊆ U → U = Z
-  := zorn_subset_nonempty { T : Theory α | (𝓓)-Consistent T } (by
+lemma exists_maximal_consistent_theory
+  : ∃ Z, (Λ)-Consistent Z ∧ T ⊆ Z ∧ ∀ U, (Λ)-Consistent U → Z ⊆ U → U = Z
+  := zorn_subset_nonempty { T : Theory α | (Λ)-Consistent T } (by
     intro c hc chain hnc;
     existsi (⋃₀ c);
-    simp only [Consistent, Set.mem_setOf_eq, Set.mem_sUnion];
+    simp only [Set.mem_setOf_eq, Set.mem_sUnion];
     constructor;
-    . intro Γ;
-      by_contra hC;
-      obtain ⟨hΓs, hΓd⟩ := by simpa using hC;
+    . apply def_consistent.mpr;
+      intro Γ hΓ; by_contra hC;
       obtain ⟨U, hUc, hUs⟩ :=
         Set.subset_mem_chain_of_finite c hnc chain
           (s := ↑Γ.toFinset) (by simp)
           (by intro p hp; simp_all);
       simp [List.coe_toFinset] at hUs;
-      have : (𝓓)-Consistent U := hc hUc;
-      have : ¬(𝓓)-Consistent U := by
-        simp only [Consistent, not_forall, not_not, exists_prop];
-        existsi Γ;
+      have : (Λ)-Consistent U := hc hUc;
+      have : ¬(Λ)-Consistent U := by
+        apply def_inconsistent.mpr;
+        use Γ;
         constructor;
         . intro p hp; exact hUs hp;
         . assumption;
       contradiction;
     . intro s a;
       exact Set.subset_sUnion_of_mem a;
-  ) T hConsis
-protected alias lindenbaum := exists_maximal_Consistent_theory
+  ) T T_consis
+protected alias lindenbaum := exists_maximal_consistent_theory
 
 open Classical in
-lemma intro_union_Consistent
-  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ p ∈ Γ₁, p ∈ T₁) → (∀ p ∈ Γ₂, p ∈ T₂) → 𝓓 ⊬! ⋀Γ₁ ⋏ ⋀Γ₂ ⟶ ⊥) : (𝓓)-Consistent (T₁ ∪ T₂) := by
+lemma intro_union_consistent
+  (h : ∀ {Γ₁ Γ₂ : List (Formula α)}, (∀ p ∈ Γ₁, p ∈ T₁) → (∀ p ∈ Γ₂, p ∈ T₂) → Λ ⊬! ⋀Γ₁ ⋏ ⋀Γ₂ ⟶ ⊥) : (Λ)-Consistent (T₁ ∪ T₂) := by
+  apply def_consistent.mpr;
   intro Δ hΔ;
-  simp at hΔ;
   let Δ₁ := (Δ.filter (· ∈ T₁));
   let Δ₂ := (Δ.filter (· ∈ T₂));
-  have : 𝓓 ⊬! ⋀Δ₁ ⋏ ⋀Δ₂ ⟶ ⊥ := @h Δ₁ Δ₂ (by intro _ h; simpa using List.of_mem_filter h) (by intro _ h; simpa using List.of_mem_filter h);
+  have : Λ ⊬! ⋀Δ₁ ⋏ ⋀Δ₂ ⟶ ⊥ := @h Δ₁ Δ₂ (by intro _ h; simpa using List.of_mem_filter h) (by intro _ h; simpa using List.of_mem_filter h);
   exact unprovable_imp_trans''! (by
     apply FiniteContext.deduct'!;
     apply iff_provable_list_conj.mpr;
@@ -205,32 +226,24 @@ lemma intro_union_Consistent
     . exact iff_provable_list_conj.mp (and₂'! FiniteContext.id!) q $ List.mem_filter_of_mem hq (by simpa);
   ) this;
 
-lemma not_singleton_consistent [𝓓.HasNecessitation] (h : ~(□p) ∈ T) : (𝓓)-Consistent {~p} := by
-  intro Γ hΓ;
-  simp only [Set.mem_singleton_iff] at hΓ;
-  by_contra hC;
-  have : 𝓓 ⊢! ~(□p) ⟶ ⊥ := neg_equiv'!.mp $ dni'! $ nec! $ dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
-  have : 𝓓 ⊬! ~(□p) ⟶ ⊥ := by simpa using hConsis (Γ := [~(□p)]) (by aesop)
-  contradiction;
-
 end Theory
 
-structure MaximalConsistentTheory (𝓓 : DeductionParameter α) where
+structure MaximalConsistentTheory (Λ : DeductionParameter α) where
   theory : Theory α
-  consistent : (𝓓)-Consistent theory
-  maximal : ∀ {U}, theory ⊂ U → ¬(𝓓)-Consistent U
+  consistent : (Λ)-Consistent theory
+  maximal : ∀ {U}, theory ⊂ U → ¬(Λ)-Consistent U
 
-notation "(" 𝓓 ")-MCT" => MaximalConsistentTheory 𝓓
+notation "(" Λ ")-MCT" => MaximalConsistentTheory Λ
 
 namespace MaximalConsistentTheory
 
 open Theory
 
-variable {𝓓 : DeductionParameter α}
-variable {Ω Ω₁ Ω₂ : (𝓓)-MCT}
+variable {Λ : DeductionParameter α}
+variable {Ω Ω₁ Ω₂ : (Λ)-MCT}
 variable {p : Formula α}
 
-lemma exists_maximal_Lconsistented_theory (consisT : (𝓓)-Consistent T) : ∃ Ω : (𝓓)-MCT, (T ⊆ Ω.theory) := by
+lemma exists_maximal_Lconsistented_theory (consisT : (Λ)-Consistent T) : ∃ Ω : (Λ)-MCT, (T ⊆ Ω.theory) := by
   have ⟨Ω, hΩ₁, hΩ₂, hΩ₃⟩ := Theory.lindenbaum consisT;
   existsi ⟨
     Ω,
@@ -246,39 +259,39 @@ lemma exists_maximal_Lconsistented_theory (consisT : (𝓓)-Consistent T) : ∃ 
 
 alias lindenbaum := exists_maximal_Lconsistented_theory
 
-noncomputable instance [System.Consistent 𝓓] : Inhabited (𝓓)-MCT := ⟨lindenbaum self_Consistent |>.choose⟩
+noncomputable instance [System.Consistent Λ] : Inhabited (Λ)-MCT := ⟨lindenbaum emptyset_consistent |>.choose⟩
 
-lemma either_mem (Ω : (𝓓)-MCT) (p) : p ∈ Ω.theory ∨ ~p ∈ Ω.theory := by
+lemma either_mem (Ω : (Λ)-MCT) (p) : p ∈ Ω.theory ∨ ~p ∈ Ω.theory := by
   by_contra hC; push_neg at hC;
   cases either_consistent Ω.consistent p with
   | inl h => have := Ω.maximal (Set.ssubset_insert hC.1); contradiction;
   | inr h => have := Ω.maximal (Set.ssubset_insert hC.2); contradiction;
 
-lemma maximal' {p : Formula α} (hp : p ∉ Ω.theory) : ¬(𝓓)-Consistent (insert p Ω.theory) := Ω.maximal (Set.ssubset_insert hp)
+lemma maximal' {p : Formula α} (hp : p ∉ Ω.theory) : ¬(Λ)-Consistent (insert p Ω.theory) := Ω.maximal (Set.ssubset_insert hp)
 
-lemma membership_iff : (p ∈ Ω.theory) ↔ (Ω.theory *⊢[𝓓]! p) := by
+lemma membership_iff : (p ∈ Ω.theory) ↔ (Ω.theory *⊢[Λ]! p) := by
   constructor;
   . intro h; exact Context.by_axm! h;
   . intro hp;
     suffices ~p ∉ Ω.theory by apply or_iff_not_imp_right.mp $ (either_mem Ω p); assumption;
     by_contra hC;
-    have hnp : Ω.theory *⊢[𝓓]! ~p := Context.by_axm! hC;
+    have hnp : Ω.theory *⊢[Λ]! ~p := Context.by_axm! hC;
     have := neg_mdp! hnp hp;
-    have := not_provable_falsum Ω.consistent;
+    have := Ω.consistent;
     contradiction;
 
-lemma subset_axiomset : Ax(𝓓) ⊆ Ω.theory := by
+lemma subset_axiomset : Ax(Λ) ⊆ Ω.theory := by
   intro p hp;
   apply membership_iff.mpr;
   apply Context.of!;
   exact Deduction.maxm! (by aesop);
 
-@[simp] lemma not_mem_falsum : ⊥ ∉ Ω.theory := not_mem_falsum_of_Consistent Ω.consistent
+@[simp] lemma not_mem_falsum : ⊥ ∉ Ω.theory := not_mem_falsum_of_consistent Ω.consistent
 
 @[simp] lemma mem_verum : ⊤ ∈ Ω.theory := by apply membership_iff.mpr; apply verum!;
 
 @[simp]
-lemma unprovable_falsum : Ω.theory *⊬[𝓓]! ⊥ := by apply membership_iff.not.mp; simp
+lemma unprovable_falsum : Ω.theory *⊬[Λ]! ⊥ := by apply membership_iff.not.mp; simp
 
 @[simp]
 lemma iff_mem_neg : (~p ∈ Ω.theory) ↔ (p ∉ Ω.theory) := by
@@ -287,11 +300,11 @@ lemma iff_mem_neg : (~p ∈ Ω.theory) ↔ (p ∉ Ω.theory) := by
     by_contra hp;
     replace hp := membership_iff.mp hp;
     replace hnp := membership_iff.mp hnp;
-    have : Ω.theory *⊢[𝓓]! ⊥ := neg_mdp! hnp hp;
-    have : Ω.theory *⊬[𝓓]! ⊥ := unprovable_falsum;
+    have : Ω.theory *⊢[Λ]! ⊥ := neg_mdp! hnp hp;
+    have : Ω.theory *⊬[Λ]! ⊥ := unprovable_falsum;
     contradiction;
   . intro hp;
-    have := provable_iff_insert_neg_not_Consistent.not.mp $ membership_iff.not.mp hp;
+    have := provable_iff_insert_neg_not_consistent.not.mp $ membership_iff.not.mp hp;
     have := (not_imp_not.mpr $ Ω.maximal (U := insert (~p) Ω.theory)) this;
     simp [Set.ssubset_def] at this;
     apply this;
@@ -342,8 +355,8 @@ lemma iff_mem_or : ((p ⋎ q) ∈ Ω.theory) ↔ (p ∈ Ω.theory) ∨ (q ∈ Ω
     have ⟨hp, hq⟩ := hC;
     replace hp := membership_iff.mp $ iff_mem_neg.mpr hp;
     replace hq := membership_iff.mp $ iff_mem_neg.mpr hq;
-    have : Ω.theory *⊢[𝓓]! ⊥ := or₃'''! (neg_equiv'!.mp hp) (neg_equiv'!.mp hq) hpq;
-    have : Ω.theory *⊬[𝓓]! ⊥ := unprovable_falsum;
+    have : Ω.theory *⊢[Λ]! ⊥ := or₃'''! (neg_equiv'!.mp hp) (neg_equiv'!.mp hq) hpq;
+    have : Ω.theory *⊬[Λ]! ⊥ := unprovable_falsum;
     contradiction;
   . rintro (hp | hq);
     . apply membership_iff.mpr;
@@ -351,7 +364,7 @@ lemma iff_mem_or : ((p ⋎ q) ∈ Ω.theory) ↔ (p ∈ Ω.theory) ∨ (q ∈ Ω
     . apply membership_iff.mpr;
       exact or₂'! (membership_iff.mp hq);
 
-lemma iff_congr : (Ω.theory *⊢[𝓓]! (p ⟷ q)) → ((p ∈ Ω.theory) ↔ (q ∈ Ω.theory)) := by
+lemma iff_congr : (Ω.theory *⊢[Λ]! (p ⟷ q)) → ((p ∈ Ω.theory) ↔ (q ∈ Ω.theory)) := by
   intro hpq;
   constructor;
   . intro hp; exact iff_mem_imp.mp (membership_iff.mpr $ and₁'! hpq) hp;
@@ -386,26 +399,26 @@ lemma neg_imp (h : q ∈ Ω₂.theory → p ∈ Ω₁.theory) : (~p ∈ Ω₁.th
 
 lemma neg_iff (h : p ∈ Ω₁.theory ↔ q ∈ Ω₂.theory) : (~p ∈ Ω₁.theory) ↔ (~q ∈ Ω₂.theory) := ⟨neg_imp $ h.mpr, neg_imp $ h.mp⟩
 
--- These lemmata require 𝓓 normality
+-- These lemmata require Λ normality
 section Normal
 
-variable [𝓓.IsNormal]
+variable [Λ.IsNormal]
 
-lemma iff_mem_multibox : (□^[n]p ∈ Ω.theory) ↔ (∀ {Ω' : (𝓓)-MCT}, (□''⁻¹^[n]Ω.theory ⊆ Ω'.theory) → (p ∈ Ω'.theory)) := by
+lemma iff_mem_multibox : (□^[n]p ∈ Ω.theory) ↔ (∀ {Ω' : (Λ)-MCT}, (□''⁻¹^[n]Ω.theory ⊆ Ω'.theory) → (p ∈ Ω'.theory)) := by
   constructor;
   . intro hp Ω' hΩ'; apply hΩ'; simpa;
   . contrapose;
     push_neg;
     intro hp;
-    obtain ⟨Ω', hΩ'⟩ := lindenbaum (𝓓 := 𝓓) (T := insert (~p) (□''⁻¹^[n]Ω.theory)) (by
-      apply unprovable_iff_insert_neg_Consistent.mp;
+    obtain ⟨Ω', hΩ'⟩ := lindenbaum (Λ := Λ) (T := insert (~p) (□''⁻¹^[n]Ω.theory)) (by
+      apply unprovable_iff_insert_neg_consistent.mp;
       by_contra hC;
       obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Context.provable_iff.mp hC;
-      have : 𝓓 ⊢! □^[n]⋀Γ ⟶ □^[n]p := imply_multibox_distribute'! hΓ₂;
-      have : 𝓓 ⊬! □^[n]⋀Γ ⟶ □^[n]p := by
+      have : Λ ⊢! □^[n]⋀Γ ⟶ □^[n]p := imply_multibox_distribute'! hΓ₂;
+      have : Λ ⊬! □^[n]⋀Γ ⟶ □^[n]p := by
         have := Context.provable_iff.not.mp $ membership_iff.not.mp hp;
         push_neg at this;
-        have : 𝓓 ⊬! ⋀□'^[n]Γ ⟶ □^[n]p := FiniteContext.provable_iff.not.mp $ this (□'^[n]Γ) (by
+        have : Λ ⊬! ⋀□'^[n]Γ ⟶ □^[n]p := FiniteContext.provable_iff.not.mp $ this (□'^[n]Γ) (by
           intro q hq;
           obtain ⟨r, hr₁, hr₂⟩ := by simpa using hq;
           subst hr₂;
@@ -423,7 +436,7 @@ lemma iff_mem_multibox : (□^[n]p ∈ Ω.theory) ↔ (∀ {Ω' : (𝓓)-MCT}, (
     . apply iff_mem_neg.mp;
       apply hΩ';
       simp only [Set.mem_insert_iff, true_or]
-lemma iff_mem_box : (□p ∈ Ω.theory) ↔ (∀ {Ω' : (𝓓)-MCT}, (□''⁻¹Ω.theory ⊆ Ω'.theory) → (p ∈ Ω'.theory)) := iff_mem_multibox (n := 1)
+lemma iff_mem_box : (□p ∈ Ω.theory) ↔ (∀ {Ω' : (Λ)-MCT}, (□''⁻¹Ω.theory ⊆ Ω'.theory) → (p ∈ Ω'.theory)) := iff_mem_multibox (n := 1)
 
 lemma multibox_dn_iff : (□^[n](~~p) ∈ Ω.theory) ↔ (□^[n]p ∈ Ω.theory) := by
   simp only [iff_mem_multibox];

--- a/Logic/Modal/Standard/ConsistentTheory.lean
+++ b/Logic/Modal/Standard/ConsistentTheory.lean
@@ -38,7 +38,7 @@ lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List 
   constructor;
   . intro h Γ hΓ;
     by_contra hC;
-    have : 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⊥ := implyLeft_cons_conj'!.not.mp $ @h (p :: Γ) (by
+    have : 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⊥ := iff_imply_left_cons_conj'!.not.mp $ @h (p :: Γ) (by
       rintro q hq;
       simp at hq;
       cases hq with
@@ -55,7 +55,7 @@ lemma iff_insert_Consistent : (𝓓)-Consistent (insert p T) ↔ ∀ {Γ : List 
       | inr h => assumption;
     );
     by_contra hC;
-    have := imp_trans''! and_comm! $ imply_left_remove_conj'! (p := p) hC;
+    have := imp_trans''! and_comm! $ imply_left_remove_conj! (p := p) hC;
     contradiction;
 
 lemma iff_insert_Inconsistent : ¬(𝓓)-Consistent (insert p T) ↔ ∃ Γ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ 𝓓 ⊢! p ⋏ ⋀Γ ⟶ ⊥ := by
@@ -151,7 +151,7 @@ lemma either_consistent (p) : (𝓓)-Consistent (insert p T) ∨ (𝓓)-Consiste
   replace hΓ₂ := neg_equiv'!.mpr hΓ₂;
   replace hΔ₂ := neg_equiv'!.mpr hΔ₂;
   have : 𝓓 ⊢! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := neg_equiv'!.mp $ demorgan₁'! $ or₃'''! (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΓ₂) or₁!) (imp_trans''! (imply_of_not_or'! $ demorgan₄'! hΔ₂) or₂!) lem!
-  have : 𝓓 ⊬! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj'! (hConsis (by
+  have : 𝓓 ⊬! ⋀Γ ⋏ ⋀Δ ⟶ ⊥ := unprovable_imp_trans''! imply_left_concat_conj! (hConsis (by
     simp;
     intro q hq;
     rcases hq with hΓ | hΔ
@@ -209,7 +209,7 @@ lemma not_singleton_consistent [𝓓.HasNecessitation] (h : ~(□p) ∈ T) : (�
   intro Γ hΓ;
   simp only [Set.mem_singleton_iff] at hΓ;
   by_contra hC;
-  have : 𝓓 ⊢! ~(□p) ⟶ ⊥ := neg_equiv'!.mp $ dni'! $ nec! $ dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj'! hΓ hC;
+  have : 𝓓 ⊢! ~(□p) ⟶ ⊥ := neg_equiv'!.mp $ dni'! $ nec! $ dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
   have : 𝓓 ⊬! ~(□p) ⟶ ⊥ := by simpa using hConsis (Γ := [~(□p)]) (by aesop)
   contradiction;
 
@@ -414,7 +414,7 @@ lemma iff_mem_multibox : (□^[n]p ∈ Ω.theory) ↔ (∀ {Ω' : (𝓓)-MCT}, (
         revert this;
         contrapose;
         simp [neg_neg];
-        exact imp_trans''! collect_multibox_conj'!;
+        exact imp_trans''! collect_multibox_conj!;
       contradiction;
     );
     existsi Ω';
@@ -496,17 +496,17 @@ lemma multibox_multidia : (∀ {p : Formula α}, (□^[n]p ∈ Ω₁.theory → 
 
 variable {Γ : List (Formula α)}
 
-lemma iff_mem_conj' : (⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, p ∈ Ω.theory) := by simp [membership_iff, iff_provable_list_conj];
+lemma iff_mem_conj : (⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, p ∈ Ω.theory) := by simp [membership_iff, iff_provable_list_conj];
 
-lemma iff_mem_multibox_conj' : (□^[n]⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □^[n]p ∈ Ω.theory) := by
-  simp only [iff_mem_multibox, iff_mem_conj'];
+lemma iff_mem_multibox_conj : (□^[n]⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □^[n]p ∈ Ω.theory) := by
+  simp only [iff_mem_multibox, iff_mem_conj];
   constructor;
   . intro h p hp Ω' hΩ';
     exact (h hΩ') p hp;
   . intro h Ω' hΩ' p hp;
     exact @h p hp Ω' hΩ';
 
-lemma iff_mem_box_conj' : (□⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □p ∈ Ω.theory) := iff_mem_multibox_conj' (n := 1)
+lemma iff_mem_box_conj : (□⋀Γ ∈ Ω.theory) ↔ (∀ p ∈ Γ, □p ∈ Ω.theory) := iff_mem_multibox_conj (n := 1)
 
 end Normal
 

--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -43,28 +43,28 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
         intro Γ Δ hΓ hΔ hC;
 
         replace hΓ : ∀ p ∈ Γ, □p ∈ Ω₁.theory := by simpa using hΓ;
-        have dΓconj : Ω₁.theory *⊢[_]! □Γ.conj' := membership_iff.mp $ iff_mem_box_conj'.mpr hΓ;
+        have dΓconj : Ω₁.theory *⊢[_]! □⋀Γ := membership_iff.mp $ iff_mem_box_conj'.mpr hΓ;
 
         have hΔ₂ : ∀ p ∈ ◇'⁻¹^[n]Δ, p ∈ Ω₂.theory := by
           intro p hp;
           simpa using hΔ (◇^[n]p) (by simp_all);
 
-        have hΔconj : (◇'⁻¹^[n]Δ).conj' ∈ Ω₂.theory := iff_mem_conj'.mpr hΔ₂;
+        have hΔconj : ⋀◇'⁻¹^[n]Δ ∈ Ω₂.theory := iff_mem_conj'.mpr hΔ₂;
 
-        have : (◇'⁻¹^[n]Δ).conj' ∉ Ω₂.theory := by {
-          have d₁ : 𝝂Ax ⊢! Γ.conj' ⟶ Δ.conj' ⟶ ⊥ := and_imply_iff_imply_imply'!.mp hC;
-          have : 𝝂Ax ⊢! (◇'^[n]◇'⁻¹^[n]Δ).conj' ⟶ Δ.conj' := by
+        have : ⋀◇'⁻¹^[n]Δ ∉ Ω₂.theory := by {
+          have d₁ : 𝝂Ax ⊢! ⋀Γ ⟶ ⋀Δ ⟶ ⊥ := and_imply_iff_imply_imply'!.mp hC;
+          have : 𝝂Ax ⊢! ⋀(◇'^[n]◇'⁻¹^[n]Δ) ⟶ ⋀Δ := by
             apply conj'conj'_subset;
             intro q hq;
             obtain ⟨r, _, _⟩ := hΔ q hq;
             subst_vars;
             simpa;
-          have : 𝝂Ax ⊢! ◇^[n](◇'⁻¹^[n]Δ).conj' ⟶ Δ.conj' := imp_trans''! iff_conj'multidia_multidiaconj'! $ this;
-          have : 𝝂Ax ⊢! ~(□^[n](~(◇'⁻¹^[n]Δ).conj')) ⟶ Δ.conj' := imp_trans''! (and₂'! multidia_duality!) this;
-          have : 𝝂Ax ⊢! ~Δ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := contra₂'! this;
-          have : 𝝂Ax ⊢! (Δ.conj' ⟶ ⊥) ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := imp_trans''! (and₂'! neg_equiv!) this;
-          have : 𝝂Ax ⊢! Γ.conj' ⟶ □^[n](~(◇'⁻¹^[n]Δ).conj') := imp_trans''! d₁ this;
-          have : 𝝂Ax ⊢! □Γ.conj' ⟶ □^[(n + 1)](~(◇'⁻¹^[n]Δ).conj') := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
+          have : 𝝂Ax ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ⟶ ⋀Δ := imp_trans''! iff_conj'multidia_multidiaconj'! $ this;
+          have : 𝝂Ax ⊢! ~(□^[n](~⋀◇'⁻¹^[n]Δ)) ⟶ ⋀Δ := imp_trans''! (and₂'! multidia_duality!) this;
+          have : 𝝂Ax ⊢! ~⋀Δ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := contra₂'! this;
+          have : 𝝂Ax ⊢! (⋀Δ ⟶ ⊥) ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! (and₂'! neg_equiv!) this;
+          have : 𝝂Ax ⊢! ⋀Γ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! d₁ this;
+          have : 𝝂Ax ⊢! □⋀Γ ⟶ □^[(n + 1)](~⋀◇'⁻¹^[n]Δ) := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
           exact iff_mem_neg.mp $ h $ membership_iff.mpr $ (Context.of! this) ⨀ dΓconj;
         }
 

--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -43,23 +43,23 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
         intro Γ Δ hΓ hΔ hC;
 
         replace hΓ : ∀ p ∈ Γ, □p ∈ Ω₁.theory := by simpa using hΓ;
-        have dΓconj : Ω₁.theory *⊢[_]! □⋀Γ := membership_iff.mp $ iff_mem_box_conj'.mpr hΓ;
+        have dΓconj : Ω₁.theory *⊢[_]! □⋀Γ := membership_iff.mp $ iff_mem_box_conj.mpr hΓ;
 
         have hΔ₂ : ∀ p ∈ ◇'⁻¹^[n]Δ, p ∈ Ω₂.theory := by
           intro p hp;
           simpa using hΔ (◇^[n]p) (by simp_all);
 
-        have hΔconj : ⋀◇'⁻¹^[n]Δ ∈ Ω₂.theory := iff_mem_conj'.mpr hΔ₂;
+        have hΔconj : ⋀◇'⁻¹^[n]Δ ∈ Ω₂.theory := iff_mem_conj.mpr hΔ₂;
 
         have : ⋀◇'⁻¹^[n]Δ ∉ Ω₂.theory := by {
           have d₁ : 𝝂Ax ⊢! ⋀Γ ⟶ ⋀Δ ⟶ ⊥ := and_imply_iff_imply_imply'!.mp hC;
           have : 𝝂Ax ⊢! ⋀(◇'^[n]◇'⁻¹^[n]Δ) ⟶ ⋀Δ := by
-            apply conj'conj'_subset;
+            apply conjconj_subset!;
             intro q hq;
             obtain ⟨r, _, _⟩ := hΔ q hq;
             subst_vars;
             simpa;
-          have : 𝝂Ax ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ⟶ ⋀Δ := imp_trans''! iff_conj'multidia_multidiaconj'! $ this;
+          have : 𝝂Ax ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ⟶ ⋀Δ := imp_trans''! iff_conjmultidia_multidiaconj! $ this;
           have : 𝝂Ax ⊢! ~(□^[n](~⋀◇'⁻¹^[n]Δ)) ⟶ ⋀Δ := imp_trans''! (and₂'! multidia_duality!) this;
           have : 𝝂Ax ⊢! ~⋀Δ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := contra₂'! this;
           have : 𝝂Ax ⊢! (⋀Δ ⟶ ⊥) ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! (and₂'! neg_equiv!) this;
@@ -134,7 +134,7 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Ax) ⊧ p ↔ ((�
     have : (𝝂Ax)-Consistent ({~p}) := by
       intro Γ hΓ;
       by_contra hC;
-      have : 𝝂Ax ⊢! p := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj'! hΓ hC;
+      have : 𝝂Ax ⊢! p := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
       contradiction;
     obtain ⟨Ω, hΩ⟩ := lindenbaum this;
     simp [Kripke.ValidOnModel];

--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -15,7 +15,7 @@ namespace Kripke
 
 abbrev CanonicalFrame (Ax : AxiomSet α) [Inhabited (𝝂Ax)-MCT] : Frame where
   World := (𝝂Ax)-MCT
-  Rel := λ Ω₁ Ω₂ => □''⁻¹Ω₁.theory ⊆ Ω₂.theory
+  Rel Ω₁ Ω₂ := □''⁻¹Ω₁.theory ⊆ Ω₂.theory
 
 namespace CanonicalFrame
 
@@ -38,8 +38,8 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
       obtain ⟨⟨Ω₃, _⟩, R₁₃, R₃₂⟩ := h;
       apply ih.mp R₃₂ $ frame_def_box.mp R₁₃ (by simpa using hp);
     . intro h;
-      obtain ⟨Ω, hΩ⟩ := lindenbaum (𝓓 := (𝝂Ax)) (T := (□''⁻¹Ω₁.theory ∪ ◇''^[n]Ω₂.theory)) $ by
-        apply Theory.intro_union_Consistent;
+      obtain ⟨Ω, hΩ⟩ := lindenbaum (Λ := 𝝂Ax) (T := (□''⁻¹Ω₁.theory ∪ ◇''^[n]Ω₂.theory)) $ by
+        apply Theory.intro_union_consistent;
         intro Γ Δ hΓ hΔ hC;
 
         replace hΓ : ∀ p ∈ Γ, □p ∈ Ω₁.theory := by simpa using hΓ;
@@ -132,6 +132,7 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Ax) ⊧ p ↔ ((�
   . contrapose;
     intro h;
     have : (𝝂Ax)-Consistent ({~p}) := by
+      apply Theory.def_consistent.mpr;
       intro Γ hΓ;
       by_contra hC;
       have : 𝝂Ax ⊢! p := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
@@ -143,8 +144,10 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Ax) ⊧ p ↔ ((�
   . intro h Ω;
     suffices p ∈ Ω.theory by exact truthlemma.mpr this;
     by_contra hC;
-    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Theory.iff_insert_Inconsistent.mp $ Ω.maximal' hC;
-    exact Ω.consistent hΓ₁ $ and_imply_iff_imply_imply'!.mp hΓ₂ ⨀ h;
+    obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Theory.iff_insert_inconsistent.mp $ Ω.maximal' hC;
+    have : Γ ⊢[𝝂Ax]! ⊥ := FiniteContext.provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hΓ₂ ⨀ h;
+    have : Γ ⊬[𝝂Ax]! ⊥ := Theory.def_consistent.mp Ω.consistent _ hΓ₁;
+    contradiction;
 
 lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Ax) ⊧* Ax := by
   apply Semantics.realizeSet_iff.mpr;

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -241,8 +241,8 @@ variable {Ax : AxiomSet α} [System.Consistent (𝝂Ax)]
 lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t (CanonicalFrame Ax):= by
   rintro Ω₁ Ω₂ Ω₃ h;
   have ⟨r₁₂, r₁₃⟩ := h; clear h;
-  have ⟨Ω, hΩ⟩ := lindenbaum (𝓓 := (𝝂Ax)) (T := ((□''⁻¹^[t.m]Ω₂.theory) ∪ (□''⁻¹^[t.n]Ω₃.theory))) $ by
-    apply intro_union_Consistent;
+  have ⟨Ω, hΩ⟩ := lindenbaum (Λ := 𝝂Ax) (T := □''⁻¹^[t.m]Ω₂.theory ∪ □''⁻¹^[t.n]Ω₃.theory) $ by
+    apply intro_union_consistent;
     intro Γ Δ hΓ hΔ hC;
 
     replace hΓ : ∀ p ∈ Γ, □^[t.m]p ∈ Ω₂.theory := by simpa using hΓ;
@@ -262,7 +262,7 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
         (show 𝝂Ax ⊢! □^[t.n]⋀Δ ⟶ □^[t.n](~⋀Γ) by exact imply_multibox_distribute'! $ contra₁'! $ imp_trans''! (and_imply_iff_imply_imply'!.mp hC) (and₂'! neg_equiv!))
         (show 𝝂Ax ⊢! □^[t.n](~⋀Γ) ⟶ (◇^[t.n]⋀Γ) ⟶ ⊥ by exact imp_trans''! (contra₁'! $ and₁'! $ multidia_duality!) (and₁'! neg_equiv!));
     }
-    have : 𝝂Ax ⊬! □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ⟶ ⊥ := by simpa using Ω₃.consistent (Γ := [□^[t.n]⋀Δ, ◇^[t.n]⋀Γ]) (by simp_all)
+    have : 𝝂Ax ⊬! □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ⟶ ⊥ := by simpa using (def_consistent.mp Ω₃.consistent) (Γ := [□^[t.n]⋀Δ, ◇^[t.n]⋀Γ]) (by simp_all)
 
     contradiction;
 

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -246,10 +246,10 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
     intro Γ Δ hΓ hΔ hC;
 
     replace hΓ : ∀ p ∈ Γ, □^[t.m]p ∈ Ω₂.theory := by simpa using hΓ;
-    have hΓconj : □^[t.m]⋀Γ ∈ Ω₂.theory := iff_mem_multibox_conj'.mpr hΓ;
+    have hΓconj : □^[t.m]⋀Γ ∈ Ω₂.theory := iff_mem_multibox_conj.mpr hΓ;
 
     replace hΔ : ∀ p ∈ Δ, □^[t.n]p ∈ Ω₃.theory := by simpa using hΔ;
-    have : □^[t.n]⋀Δ ∈ Ω₃.theory := iff_mem_multibox_conj'.mpr hΔ;
+    have : □^[t.n]⋀Δ ∈ Ω₃.theory := iff_mem_multibox_conj.mpr hΔ;
 
     have : □^[t.j](◇^[t.n]⋀Γ) ∈ Ω₁.theory := iff_mem_imp.mp
       (membership_iff.mpr $ Context.of! $ Normal.maxm! (by aesop))

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -246,23 +246,23 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
     intro Γ Δ hΓ hΔ hC;
 
     replace hΓ : ∀ p ∈ Γ, □^[t.m]p ∈ Ω₂.theory := by simpa using hΓ;
-    have hΓconj : □^[t.m](Γ.conj') ∈ Ω₂.theory := iff_mem_multibox_conj'.mpr hΓ;
+    have hΓconj : □^[t.m]⋀Γ ∈ Ω₂.theory := iff_mem_multibox_conj'.mpr hΓ;
 
     replace hΔ : ∀ p ∈ Δ, □^[t.n]p ∈ Ω₃.theory := by simpa using hΔ;
-    have : □^[t.n](Δ.conj') ∈ Ω₃.theory := iff_mem_multibox_conj'.mpr hΔ;
+    have : □^[t.n]⋀Δ ∈ Ω₃.theory := iff_mem_multibox_conj'.mpr hΔ;
 
-    have : □^[t.j](◇^[t.n](Γ.conj')) ∈ Ω₁.theory := iff_mem_imp.mp
+    have : □^[t.j](◇^[t.n]⋀Γ) ∈ Ω₁.theory := iff_mem_imp.mp
       (membership_iff.mpr $ Context.of! $ Normal.maxm! (by aesop))
       (multiframe_def_multidia.mp r₁₂ hΓconj)
-    have : ◇^[t.n]Γ.conj' ∈ Ω₃.theory := multiframe_def_multibox.mp r₁₃ this;
+    have : ◇^[t.n]⋀Γ ∈ Ω₃.theory := multiframe_def_multibox.mp r₁₃ this;
 
-    have : 𝝂Ax ⊢! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by {
+    have : 𝝂Ax ⊢! □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ⟶ ⊥ := by {
       apply and_imply_iff_imply_imply'!.mpr;
       exact imp_trans''!
-        (show 𝝂Ax ⊢! □^[t.n](Δ.conj') ⟶ □^[t.n](~Γ.conj') by exact imply_multibox_distribute'! $ contra₁'! $ imp_trans''! (and_imply_iff_imply_imply'!.mp hC) (and₂'! neg_equiv!))
-        (show 𝝂Ax ⊢! □^[t.n](~Γ.conj') ⟶ (◇^[t.n]Γ.conj') ⟶ ⊥ by exact imp_trans''! (contra₁'! $ and₁'! $ multidia_duality!) (and₁'! neg_equiv!));
+        (show 𝝂Ax ⊢! □^[t.n]⋀Δ ⟶ □^[t.n](~⋀Γ) by exact imply_multibox_distribute'! $ contra₁'! $ imp_trans''! (and_imply_iff_imply_imply'!.mp hC) (and₂'! neg_equiv!))
+        (show 𝝂Ax ⊢! □^[t.n](~⋀Γ) ⟶ (◇^[t.n]⋀Γ) ⟶ ⊥ by exact imp_trans''! (contra₁'! $ and₁'! $ multidia_duality!) (and₁'! neg_equiv!));
     }
-    have : 𝝂Ax ⊬! □^[t.n](Δ.conj') ⋏ ◇^[t.n](Γ.conj') ⟶ ⊥ := by simpa using Ω₃.consistent (Γ := [□^[t.n](Δ.conj'), ◇^[t.n](Γ.conj')]) (by simp_all)
+    have : 𝝂Ax ⊬! □^[t.n]⋀Δ ⋏ ◇^[t.n]⋀Γ ⟶ ⊥ := by simpa using Ω₃.consistent (Γ := [□^[t.n]⋀Δ, ◇^[t.n]⋀Γ]) (by simp_all)
 
     contradiction;
 

--- a/Logic/Modal/Standard/Kripke/ModalCompanion.lean
+++ b/Logic/Modal/Standard/Kripke/ModalCompanion.lean
@@ -48,7 +48,7 @@ lemma axiomTc_GTranslate! [System.K4 m𝓓] : m𝓓 ⊢! pᵍ ⟶ □pᵍ := by
     exact imp_trans''! (and_replace! ihp ihq) collect_box_and!
   | hor p q ihp ihq =>
     simp only [GoedelTranslation];
-    exact imp_trans''! (or₃''! (imply_or_left'! ihp) (imply_or_right'! ihq)) collect_box_or!
+    exact imp_trans''! (or₃''! (imply_left_or'! ihp) (imply_right_or'! ihq)) collect_box_or!
   | _ => simp only [GoedelTranslation, axiomFour!];
 
 instance [System.S4 m𝓓] : System.K4 m𝓓 where
@@ -144,7 +144,7 @@ instance : ModalCompanion (α := α) 𝐈𝐧𝐭 𝐒𝟒 := ⟨provable_efq_if
 
 lemma dp_of_mdp [ModalDisjunctive m𝓓] [ModalCompanion i𝓓 m𝓓] [System.S4 m𝓓] : i𝓓 ⊢! p ⋎ q → i𝓓 ⊢! p ∨ i𝓓 ⊢! q := by
     intro hpq;
-    have : m𝓓 ⊢! □pᵍ ⋎ □qᵍ := or₃'''! (imply_or_left'! axiomTc_GTranslate!) (imply_or_right'! axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq);
+    have : m𝓓 ⊢! □pᵍ ⋎ □qᵍ := or₃'''! (imply_left_or'! axiomTc_GTranslate!) (imply_right_or'! axiomTc_GTranslate!) (by simpa using ModalCompanion.companion.mp hpq);
     cases ModalDisjunctive.modal_disjunctive this with
     | inl h => left; exact ModalCompanion.companion.mpr h;
     | inr h => right; exact ModalCompanion.companion.mpr h;

--- a/Logic/Modal/Standard/PLoN/Completeness.lean
+++ b/Logic/Modal/Standard/PLoN/Completeness.lean
@@ -36,7 +36,7 @@ lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ p ↔ (p ∈ Ω.
       simp [PLoN.Satisfies];
       constructor;
       . assumption;
-      . obtain ⟨Ω', hΩ'⟩ := lindenbaum (𝓓 := Λ) (T := {~p}) (not_singleton_consistent Ω.consistent (iff_mem_neg.mpr hC));
+      . obtain ⟨Ω', hΩ'⟩ := lindenbaum (Λ := Λ) (T := {~p}) (not_singleton_consistent Ω.consistent (iff_mem_neg.mpr hC));
         use Ω';
         constructor;
         . apply iff_mem_neg.mp;
@@ -58,7 +58,7 @@ lemma complete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFram
   constructor;
   . exact hFC;
   . use (CanonicalModel Λ).Valuation;
-    obtain ⟨Ω, hΩ⟩ := lindenbaum (𝓓 := Λ) (T := {~p}) (by
+    obtain ⟨Ω, hΩ⟩ := lindenbaum (Λ := Λ) (T := {~p}) (by
       apply unprovable_iff_singleton_neg_consistent.mp;
       exact h;
     );

--- a/Logic/Modal/Standard/PLoN/Completeness.lean
+++ b/Logic/Modal/Standard/PLoN/Completeness.lean
@@ -59,7 +59,7 @@ lemma complete_of_mem_canonicalFrame {𝔽 : FrameClass α} (hFC : CanonicalFram
   . exact hFC;
   . use (CanonicalModel Λ).Valuation;
     obtain ⟨Ω, hΩ⟩ := lindenbaum (𝓓 := Λ) (T := {~p}) (by
-      apply unprovable_iff_singleton_neg_Consistent.mp;
+      apply unprovable_iff_singleton_neg_consistent.mp;
       exact h;
     );
     use Ω;

--- a/Logic/Modal/Standard/System.lean
+++ b/Logic/Modal/Standard/System.lean
@@ -257,8 +257,6 @@ lemma collect_box_and'! (h : 𝓢 ⊢! □p ⋏ □q) : 𝓢 ⊢! □(p ⋏ q) :
 
 lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n]⋀Γ ↔ ∀ p ∈ Γ, 𝓢 ⊢! □^[n]p := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simp;
-  | hsingle => simp;
   | hcons p Γ h ih =>
     simp_all;
     constructor;
@@ -269,20 +267,21 @@ lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n]⋀Γ ↔ ∀ p ∈ Γ, 𝓢 ⊢! �
       . exact ih.mp (and₂'! this);
     . rintro ⟨h₁, h₂⟩;
       exact collect_multibox_and'! $ and₃'! h₁ (ih.mpr h₂);
+  | _ => simp_all;
 lemma boxConj'_iff! : 𝓢 ⊢! □⋀Γ ↔ ∀ p ∈ Γ, 𝓢 ⊢! □p := multiboxConj'_iff! (n := 1)
 
-lemma multiboxconj'_of_conj'multibox! (d : 𝓢 ⊢! ⋀□'^[n]Γ) : 𝓢 ⊢! □^[n]⋀Γ := by
+lemma multiboxconj_of_conjmultibox! (d : 𝓢 ⊢! ⋀□'^[n]Γ) : 𝓢 ⊢! □^[n]⋀Γ := by
   apply multiboxConj'_iff!.mpr;
   intro p hp;
   exact iff_provable_list_conj.mp d (□^[n]p) (by aesop);
 
 @[simp]
-lemma multibox_cons_conj'! :  𝓢 ⊢! ⋀(□'^[n](p :: Γ)) ⟶ ⋀□'^[n]Γ := by
-  apply conj'conj'_subset;
+lemma multibox_cons_conj! :  𝓢 ⊢! ⋀(□'^[n](p :: Γ)) ⟶ ⋀□'^[n]Γ := by
+  apply conjconj_subset!;
   simp_all;
 
 @[simp]
-lemma collect_multibox_conj'! : 𝓢 ⊢! ⋀□'^[n]Γ ⟶ □^[n]⋀Γ := by
+lemma collect_multibox_conj! : 𝓢 ⊢! ⋀□'^[n]Γ ⟶ □^[n]⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hnil => simpa using dhyp! multiboxverum!;
   | hsingle => simp;
@@ -291,7 +290,7 @@ lemma collect_multibox_conj'! : 𝓢 ⊢! ⋀□'^[n]Γ ⟶ □^[n]⋀Γ := by
     exact imp_trans''! (imply_right_and! (generalConj'! (by simp)) (imp_trans''! (by simp) ih)) collect_multibox_and!;
 
 @[simp]
-lemma collect_box_conj'! : 𝓢 ⊢! ⋀(□'Γ) ⟶ □(⋀Γ) := collect_multibox_conj'! (n := 1)
+lemma collect_box_conj! : 𝓢 ⊢! ⋀(□'Γ) ⟶ □(⋀Γ) := collect_multibox_conj! (n := 1)
 
 
 def collect_multibox_or : 𝓢 ⊢ □^[n]p ⋎ □^[n]q ⟶ □^[n](p ⋎ q) := or₃'' (multibox_axiomK' $ multinec or₁) (multibox_axiomK' $ multinec or₂)
@@ -333,11 +332,9 @@ def collect_dia_or' (h : 𝓢 ⊢ ◇p ⋎ ◇q) : 𝓢 ⊢ ◇(p ⋎ q) := coll
 @[simp] lemma distribute_dia_and! : 𝓢 ⊢! ◇(p ⋏ q) ⟶ ◇p ⋏ ◇q := distribute_multidia_and! (n := 1)
 
 
--- TODO: `iffConjMultidiaMultidiaconj'` is computable but it's too slow, so leave it.
-@[simp] lemma iff_conj'multidia_multidiaconj'! : 𝓢 ⊢! ◇^[n](⋀Γ) ⟶ ⋀(◇'^[n]Γ) := by
+-- TODO: `iffConjMultidiaMultidiaconj` is computable but it's too slow, so leave it.
+@[simp] lemma iff_conjmultidia_multidiaconj! : 𝓢 ⊢! ◇^[n](⋀Γ) ⟶ ⋀(◇'^[n]Γ) := by
   induction Γ using List.induction_with_singleton with
-  | hnil => simpa using dhyp! verum!;
-  | hsingle p => simp;
   | hcons p Γ h ih =>
     simp_all;
     exact imp_trans''! distribute_multidia_and! $ by
@@ -350,6 +347,7 @@ def collect_dia_or' (h : 𝓢 ⊢ ◇p ⋎ ◇q) : 𝓢 ⊢ ◇(p ⋎ q) := coll
       | inr hq =>
         obtain ⟨r, hr₁, hr₂⟩ := hq;
         exact (iff_provable_list_conj.mp $ (of'! ih) ⨀ (and₂'! $ id!)) q (by aesop);
+  | _ => simp
 
 -- def distributeDiaAnd' (h : 𝓢 ⊢ ◇(p ⋏ q)) : 𝓢 ⊢ ◇p ⋏ ◇q := distributeDiaAnd ⨀ h
 lemma distribute_dia_and'! (h : 𝓢 ⊢! ◇(p ⋏ q)) : 𝓢 ⊢! ◇p ⋏ ◇q := distribute_dia_and! ⨀ h
@@ -357,7 +355,7 @@ lemma distribute_dia_and'! (h : 𝓢 ⊢! ◇(p ⋏ q)) : 𝓢 ⊢! ◇p ⋏ ◇
 open StandardModalLogicalConnective (boxdot)
 
 def boxdotAxiomK : 𝓢 ⊢ ⊡(p ⟶ q) ⟶ (⊡p ⟶ ⊡q) := by
-  simp [boxdot]
+  simp [boxdot];
   apply deduct';
   apply deduct;
   have d : [p ⋏ □p, (p ⟶ q) ⋏ □(p ⟶ q)] ⊢[𝓢] (p ⟶ q) ⋏ □(p ⟶ q) := FiniteContext.byAxm;

--- a/Logic/Modal/Standard/System.lean
+++ b/Logic/Modal/Standard/System.lean
@@ -255,7 +255,7 @@ def collect_box_and' (h : 𝓢 ⊢ □p ⋏ □q) : 𝓢 ⊢ □(p ⋏ q) := col
 lemma collect_box_and'! (h : 𝓢 ⊢! □p ⋏ □q) : 𝓢 ⊢! □(p ⋏ q) := ⟨collect_box_and' h.some⟩
 
 
-lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n](Γ.conj') ↔ ∀ p ∈ Γ, 𝓢 ⊢! □^[n]p := by
+lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n]⋀Γ ↔ ∀ p ∈ Γ, 𝓢 ⊢! □^[n]p := by
   induction Γ using List.induction_with_singleton with
   | hnil => simp;
   | hsingle => simp;
@@ -269,20 +269,20 @@ lemma multiboxConj'_iff! : 𝓢 ⊢! □^[n](Γ.conj') ↔ ∀ p ∈ Γ, 𝓢 �
       . exact ih.mp (and₂'! this);
     . rintro ⟨h₁, h₂⟩;
       exact collect_multibox_and'! $ and₃'! h₁ (ih.mpr h₂);
-lemma boxConj'_iff! : 𝓢 ⊢! □(Γ.conj') ↔ ∀ p ∈ Γ, 𝓢 ⊢! □p := multiboxConj'_iff! (n := 1)
+lemma boxConj'_iff! : 𝓢 ⊢! □⋀Γ ↔ ∀ p ∈ Γ, 𝓢 ⊢! □p := multiboxConj'_iff! (n := 1)
 
-lemma multiboxconj'_of_conj'multibox! (d : 𝓢 ⊢! (□'^[n]Γ).conj') : 𝓢 ⊢! □^[n](Γ.conj') := by
+lemma multiboxconj'_of_conj'multibox! (d : 𝓢 ⊢! ⋀□'^[n]Γ) : 𝓢 ⊢! □^[n]⋀Γ := by
   apply multiboxConj'_iff!.mpr;
   intro p hp;
   exact iff_provable_list_conj.mp d (□^[n]p) (by aesop);
 
 @[simp]
-lemma multibox_cons_conj'! :  𝓢 ⊢! (□'^[n](p :: Γ)).conj' ⟶ (□'^[n]Γ).conj' := by
+lemma multibox_cons_conj'! :  𝓢 ⊢! ⋀(□'^[n](p :: Γ)) ⟶ ⋀□'^[n]Γ := by
   apply conj'conj'_subset;
   simp_all;
 
 @[simp]
-lemma collect_multibox_conj'! : 𝓢 ⊢! (□'^[n]Γ).conj' ⟶ □^[n](Γ.conj') := by
+lemma collect_multibox_conj'! : 𝓢 ⊢! ⋀□'^[n]Γ ⟶ □^[n]⋀Γ := by
   induction Γ using List.induction_with_singleton with
   | hnil => simpa using dhyp! multiboxverum!;
   | hsingle => simp;
@@ -291,7 +291,7 @@ lemma collect_multibox_conj'! : 𝓢 ⊢! (□'^[n]Γ).conj' ⟶ □^[n](Γ.conj
     exact imp_trans''! (imply_right_and! (generalConj'! (by simp)) (imp_trans''! (by simp) ih)) collect_multibox_and!;
 
 @[simp]
-lemma collect_box_conj'! : 𝓢 ⊢! (□'Γ).conj' ⟶ □(Γ.conj') := collect_multibox_conj'! (n := 1)
+lemma collect_box_conj'! : 𝓢 ⊢! ⋀(□'Γ) ⟶ □(⋀Γ) := collect_multibox_conj'! (n := 1)
 
 
 def collect_multibox_or : 𝓢 ⊢ □^[n]p ⋎ □^[n]q ⟶ □^[n](p ⋎ q) := or₃'' (multibox_axiomK' $ multinec or₁) (multibox_axiomK' $ multinec or₂)
@@ -334,7 +334,7 @@ def collect_dia_or' (h : 𝓢 ⊢ ◇p ⋎ ◇q) : 𝓢 ⊢ ◇(p ⋎ q) := coll
 
 
 -- TODO: `iffConjMultidiaMultidiaconj'` is computable but it's too slow, so leave it.
-@[simp] lemma iff_conj'multidia_multidiaconj'! : 𝓢 ⊢! ◇^[n](Γ.conj') ⟶ (◇'^[n]Γ).conj' := by
+@[simp] lemma iff_conj'multidia_multidiaconj'! : 𝓢 ⊢! ◇^[n](⋀Γ) ⟶ ⋀(◇'^[n]Γ) := by
   induction Γ using List.induction_with_singleton with
   | hnil => simpa using dhyp! verum!;
   | hsingle p => simp;

--- a/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
@@ -23,20 +23,20 @@ instance : HasSubset (Tableau α) := ⟨λ t₁ t₂ => t₁.1 ⊆ t₂.1 ∧ t�
   . intro h; cases h; simp;
   . rintro ⟨h₁, h₂⟩; cases t₁; cases t₂; simp_all;
 
-def ParametricConsistent (𝓓 : DeductionParameter α) (t : Tableau α) := ∀ {Γ Δ : List (Formula α)}, (∀ p ∈ Γ, p ∈ t.1) → (∀ p ∈ Δ, p ∈ t.2) → 𝓓 ⊬! Γ.conj' ⟶ Δ.disj'
+def ParametricConsistent (𝓓 : DeductionParameter α) (t : Tableau α) := ∀ {Γ Δ : List (Formula α)}, (∀ p ∈ Γ, p ∈ t.1) → (∀ p ∈ Δ, p ∈ t.2) → 𝓓 ⊬! ⋀Γ ⟶ ⋁Δ
 notation "(" 𝓓 ")-Consistent" => ParametricConsistent 𝓓
 
 
-lemma iff_ParametricConsistent_insert₁ : (𝓓)-Consistent ((insert p T), U) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → (∀ p ∈ Δ, p ∈ U) → 𝓓 ⊬! p ⋏ Γ.conj' ⟶ Δ.disj' := by
+lemma iff_ParametricConsistent_insert₁ : (𝓓)-Consistent ((insert p T), U) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → (∀ p ∈ Δ, p ∈ U) → 𝓓 ⊬! p ⋏ ⋀Γ ⟶ ⋁Δ := by
   constructor;
   . intro h Γ Δ hΓ hΔ;
     by_contra hC;
-    have : 𝓓 ⊬! (p :: Γ).conj' ⟶ Δ.disj' := h (by simp; intro q hq; right; exact hΓ q hq;) hΔ;
-    have : 𝓓 ⊢! (p :: Γ).conj' ⟶ Δ.disj' := implyLeft_cons_conj'!.mpr hC;
+    have : 𝓓 ⊬! ⋀(p :: Γ) ⟶ ⋁Δ := h (by simp; intro q hq; right; exact hΓ q hq;) hΔ;
+    have : 𝓓 ⊢! ⋀(p :: Γ) ⟶ ⋁Δ := implyLeft_cons_conj'!.mpr hC;
     contradiction;
   . intro h Γ Δ hΓ hΔ;
     simp_all only [Set.mem_insert_iff];
-    have : 𝓓 ⊬! p ⋏ (Γ.remove p).conj' ⟶ Δ.disj' := h (by
+    have : 𝓓 ⊬! p ⋏ ⋀(Γ.remove p) ⟶ ⋁Δ := h (by
       intro q hq;
       have := by simpa using hΓ q $ List.mem_of_mem_remove hq;
       cases this with
@@ -44,24 +44,24 @@ lemma iff_ParametricConsistent_insert₁ : (𝓓)-Consistent ((insert p T), U) �
       | inr h => assumption;
     ) hΔ;
     by_contra hC;
-    have : 𝓓 ⊢! p ⋏ (Γ.remove p).conj' ⟶ Δ.disj' := imp_trans''! and_comm! $ imply_left_remove_conj'! (p := p) hC;
+    have : 𝓓 ⊢! p ⋏ ⋀(Γ.remove p) ⟶ ⋁Δ := imp_trans''! and_comm! $ imply_left_remove_conj'! (p := p) hC;
     contradiction;
 
-lemma iff_not_ParametricConsistent_insert₁ : ¬(𝓓)-Consistent ((insert p T), U) ↔ ∃ Γ Δ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ (∀ p ∈ Δ, p ∈ U) ∧ 𝓓 ⊢! p ⋏ Γ.conj' ⟶ Δ.disj' := by
+lemma iff_not_ParametricConsistent_insert₁ : ¬(𝓓)-Consistent ((insert p T), U) ↔ ∃ Γ Δ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ (∀ p ∈ Δ, p ∈ U) ∧ 𝓓 ⊢! p ⋏ ⋀Γ ⟶ ⋁Δ := by
   constructor;
   . contrapose; push_neg; apply iff_ParametricConsistent_insert₁.mpr;
   . contrapose; push_neg; apply iff_ParametricConsistent_insert₁.mp;
 
-lemma iff_ParametricConsistent_insert₂ : (𝓓)-Consistent (T, (insert p U)) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → (∀ p ∈ Δ, p ∈ U) → 𝓓 ⊬! Γ.conj' ⟶ p ⋎ Δ.disj' := by
+lemma iff_ParametricConsistent_insert₂ : (𝓓)-Consistent (T, (insert p U)) ↔ ∀ {Γ Δ : List (Formula α)}, (∀ p ∈ Γ, p ∈ T) → (∀ p ∈ Δ, p ∈ U) → 𝓓 ⊬! ⋀Γ ⟶ p ⋎ ⋁Δ := by
   constructor;
   . intro h Γ Δ hΓ hΔ;
     by_contra hC;
-    have : 𝓓 ⊬! Γ.conj' ⟶ (p :: Δ).disj' := h hΓ (by simp; intro q hq; right; exact hΔ q hq);
-    have : 𝓓 ⊢! Γ.conj' ⟶ (p :: Δ).disj' := implyRight_cons_disj'!.mpr hC;
+    have : 𝓓 ⊬! ⋀Γ ⟶ ⋁(p :: Δ) := h hΓ (by simp; intro q hq; right; exact hΔ q hq);
+    have : 𝓓 ⊢! ⋀Γ ⟶ ⋁(p :: Δ) := implyRight_cons_disj'!.mpr hC;
     contradiction;
   . intro h Γ Δ hΓ hΔ;
     simp_all;
-    have : 𝓓 ⊬! Γ.conj' ⟶ p ⋎ (Δ.remove p).disj' := h hΓ (by
+    have : 𝓓 ⊬! ⋀Γ ⟶ p ⋎ ⋁(Δ.remove p) := h hΓ (by
       intro q hq;
       have := by simpa using hΔ q $ List.mem_of_mem_remove hq;
       cases this with
@@ -69,11 +69,11 @@ lemma iff_ParametricConsistent_insert₂ : (𝓓)-Consistent (T, (insert p U)) �
       | inr h => assumption;
     );
     by_contra hC;
-    have : 𝓓 ⊢! Γ.conj' ⟶ p ⋎ (Δ.remove p).disj' := imp_trans''! hC $ forthback_disj'_remove;
+    have : 𝓓 ⊢! ⋀Γ ⟶ p ⋎ ⋁(Δ.remove p) := imp_trans''! hC $ forthback_disj'_remove;
     contradiction;
 
 
-lemma iff_not_ParametricConsistent_insert₂ : ¬(𝓓)-Consistent (T, (insert p U)) ↔ ∃ Γ Δ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ (∀ p ∈ Δ, p ∈ U) ∧ 𝓓 ⊢! Γ.conj' ⟶ p ⋎ Δ.disj' := by
+lemma iff_not_ParametricConsistent_insert₂ : ¬(𝓓)-Consistent (T, (insert p U)) ↔ ∃ Γ Δ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ (∀ p ∈ Δ, p ∈ U) ∧ 𝓓 ⊢! ⋀Γ ⟶ p ⋎ ⋁Δ := by
   constructor;
   . contrapose; push_neg; apply iff_ParametricConsistent_insert₂.mpr;
   . contrapose; push_neg; apply iff_ParametricConsistent_insert₂.mp;
@@ -92,8 +92,8 @@ lemma consistent_either (p : Formula α) : (𝓓)-Consistent ((insert p t.1), t.
 
   obtain ⟨Γ₂, Δ₂, hΓ₂, hΔ₂, h₂⟩ := iff_not_ParametricConsistent_insert₂.mp hC₂;
 
-  have : 𝓓 ⊢! (Γ₁ ++ Γ₂).conj' ⟶ (Δ₁ ++ Δ₂).disj' := imp_trans''! (and₁'! iff_concat_conj!) $ imp_trans''! (cut! h₁ h₂) (and₂'! iff_concact_disj!);
-  have : 𝓓 ⊬! (Γ₁ ++ Γ₂).conj' ⟶ (Δ₁ ++ Δ₂).disj' := hCon (by simp; rintro q (hq₁ | hq₂); exact hΓ₁ q hq₁; exact hΓ₂ q hq₂) (by simp; rintro q (hq₁ | hq₂); exact hΔ₁ q hq₁; exact hΔ₂ q hq₂);
+  have : 𝓓 ⊢! ⋀(Γ₁ ++ Γ₂) ⟶ ⋁(Δ₁ ++ Δ₂) := imp_trans''! (and₁'! iff_concat_conj!) $ imp_trans''! (cut! h₁ h₂) (and₂'! iff_concact_disj!);
+  have : 𝓓 ⊬! ⋀(Γ₁ ++ Γ₂) ⟶ ⋁(Δ₁ ++ Δ₂) := hCon (by simp; rintro q (hq₁ | hq₂); exact hΓ₁ q hq₁; exact hΓ₂ q hq₂) (by simp; rintro q (hq₁ | hq₂); exact hΔ₁ q hq₁; exact hΔ₂ q hq₂);
   contradiction;
 
 lemma disjoint_of_consistent : Disjoint t.1 t.2 := by
@@ -101,16 +101,16 @@ lemma disjoint_of_consistent : Disjoint t.1 t.2 := by
   obtain ⟨T, hp₁, hp₂, hp⟩ := by simpa [Disjoint] using h;
   obtain ⟨p, hp, _⟩ := Set.not_subset.mp hp;
   simp [ParametricConsistent] at hCon;
-  have : 𝓓 ⊬! [p].conj' ⟶ [p].disj' := hCon
+  have : 𝓓 ⊬! ⋀[p] ⟶ ⋁[p] := hCon
     (by simp_all; apply hp₁; assumption)
     (by simp_all; apply hp₂; assumption);
-  have : 𝓓 ⊢! [p].conj' ⟶ [p].disj' := by simp;
+  have : 𝓓 ⊢! ⋀[p] ⟶ ⋁[p] := by simp;
   contradiction;
 
-lemma not_mem₂ {Γ : List (Formula α)} (hΓ : ∀ p ∈ Γ, p ∈ t.1) (h : 𝓓 ⊢! Γ.conj' ⟶ q) : q ∉ t.2 := by
+lemma not_mem₂ {Γ : List (Formula α)} (hΓ : ∀ p ∈ Γ, p ∈ t.1) (h : 𝓓 ⊢! ⋀Γ ⟶ q) : q ∉ t.2 := by
   by_contra hC;
-  have : 𝓓 ⊢! Γ.conj' ⟶ [q].disj' := by simpa;
-  have : 𝓓 ⊬! Γ.conj' ⟶ [q].disj' := hCon (by aesop) (by aesop);
+  have : 𝓓 ⊢! ⋀Γ ⟶ ⋁[q] := by simpa;
+  have : 𝓓 ⊬! ⋀Γ ⟶ ⋁[q] := hCon (by aesop) (by aesop);
   contradiction;
 
 end Consistent
@@ -178,7 +178,7 @@ lemma self_ParametricConsistent [h : System.Consistent 𝓓] : (𝓓)-Consistent
   by_contra hC;
   have : 𝓓 ⊢! q := by
     subst hΔ;
-    simp [List.disj'_nil] at hC;
+    simp at hC;
     exact imp_trans''! hC efq! ⨀ (by
       apply iff_provable_list_conj.mpr;
       exact λ _ hp => ⟨Deduction.eaxm $ hΓ _ hp⟩;
@@ -342,24 +342,24 @@ lemma equality_of₁ (e₁ : t₁.tableau.1 = t₂.tableau.1) : t₁ = t₂ := b
 
 lemma equality_of₂ (e₂ : t₁.tableau.2 = t₂.tableau.2) : t₁ = t₂ := equality_of₁ $ saturated_duality.mpr e₂
 
-lemma not_mem₂ {Γ : List (Formula α)} (hΓ : ∀ p ∈ Γ, p ∈ t.tableau.1) (h : 𝓓 ⊢! Γ.conj' ⟶ q) : q ∉ t.tableau.2 := t.tableau.not_mem₂ t.consistent hΓ h
+lemma not_mem₂ {Γ : List (Formula α)} (hΓ : ∀ p ∈ Γ, p ∈ t.tableau.1) (h : 𝓓 ⊢! ⋀Γ ⟶ q) : q ∉ t.tableau.2 := t.tableau.not_mem₂ t.consistent hΓ h
 
 lemma mdp₁ (hp : p ∈ t.tableau.1) (h : 𝓓 ⊢! p ⟶ q) : q ∈ t.tableau.1 := by
-  exact t.not_mem₂_iff_mem₁.mp $ not_mem₂ (by simpa) (show 𝓓 ⊢! List.conj' [p] ⟶ q by simpa;)
+  exact t.not_mem₂_iff_mem₁.mp $ not_mem₂ (by simpa) (show 𝓓 ⊢! ⋀[p] ⟶ q by simpa;)
 
 @[simp]
 lemma mem₁_verum : ⊤ ∈ t.tableau.1 := by
   apply t.not_mem₂_iff_mem₁.mp;
   by_contra hC;
-  have : 𝓓 ⊬! [].conj' ⟶ [⊤].disj' := t.consistent (by simp) (by simpa);
-  have : 𝓓 ⊢! [].conj' ⟶ [⊤].disj' := by simp;
+  have : 𝓓 ⊬! ⋀[] ⟶ ⋁[⊤] := t.consistent (by simp) (by simpa);
+  have : 𝓓 ⊢! ⋀[] ⟶ ⋁[⊤] := by simp;
   contradiction;
 
 @[simp]
 lemma not_mem₁_falsum : ⊥ ∉ t.tableau.1 := by
   by_contra hC;
-  have : 𝓓 ⊬! [⊥].conj' ⟶ [].disj' := t.consistent (by simpa) (by simp);
-  have : 𝓓 ⊢! [⊥].conj' ⟶ [].disj' := by simp;
+  have : 𝓓 ⊬! ⋀[⊥] ⟶ ⋁[] := t.consistent (by simpa) (by simp);
+  have : 𝓓 ⊢! ⋀[⊥] ⟶ ⋁[] := by simp;
   contradiction;
 
 @[simp]
@@ -368,8 +368,8 @@ lemma iff_mem₁_and : p ⋏ q ∈ t.tableau.1 ↔ p ∈ t.tableau.1 ∧ q ∈ t
   . intro h; constructor <;> exact mdp₁ h (by simp)
   . rintro ⟨hp, hq⟩;
     by_contra hC;
-    have : 𝓓 ⊢! [p, q].conj' ⟶ [p ⋏ q].disj' := by simp;
-    have : 𝓓 ⊬! [p, q].conj' ⟶ [p ⋏ q].disj' := t.consistent (by aesop) (by simpa using t.not_mem₁_iff_mem₂.mp hC);
+    have : 𝓓 ⊢! ⋀[p, q] ⟶ ⋁[p ⋏ q] := by simp;
+    have : 𝓓 ⊬! ⋀[p, q] ⟶ ⋁[p ⋏ q] := t.consistent (by aesop) (by simpa using t.not_mem₁_iff_mem₂.mp hC);
     contradiction;
 
 @[simp]
@@ -379,8 +379,8 @@ lemma iff_mem₁_or : p ⋎ q ∈ t.tableau.1 ↔ p ∈ t.tableau.1 ∨ q ∈ t.
     by_contra hC; simp [not_or] at hC;
     have : p ∈ t.tableau.2 := t.not_mem₁_iff_mem₂.mp hC.1;
     have : q ∈ t.tableau.2 := t.not_mem₁_iff_mem₂.mp hC.2;
-    have : 𝓓 ⊢! [p ⋎ q].conj' ⟶ [p, q].disj' := by simp;
-    have : 𝓓 ⊬! [p ⋎ q].conj' ⟶ [p, q].disj' := t.consistent (by simp_all) (by simp_all);
+    have : 𝓓 ⊢! ⋀[p ⋎ q] ⟶ ⋁[p, q] := by simp;
+    have : 𝓓 ⊬! ⋀[p ⋎ q] ⟶ ⋁[p, q] := t.consistent (by simp_all) (by simp_all);
     contradiction;
   . intro h;
     cases h with
@@ -449,14 +449,14 @@ private lemma truthlemma.himp
         have := by simpa using hΓ r hr₁;
         simp_all;
       by_contra hC;
-      have : 𝓓 ⊢! (Γ.remove p).conj' ⟶ (p ⟶ q) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (by
+      have : 𝓓 ⊢! ⋀(Γ.remove p) ⟶ (p ⟶ q) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (by
         apply deduct'!;
         apply deduct!;
-        have : [p, p ⟶ Δ.disj'] ⊢[𝓓]! p := by_axm!;
-        have : [p, p ⟶ Δ.disj'] ⊢[𝓓]! Δ.disj' := by_axm! ⨀ this;
+        have : [p, p ⟶ ⋁Δ] ⊢[𝓓]! p := by_axm!;
+        have : [p, p ⟶ ⋁Δ] ⊢[𝓓]! ⋁Δ := by_axm! ⨀ this;
         exact disj_allsame'! (by simpa using hΔ) this;
       )
-      have : 𝓓 ⊬! (Γ.remove p).conj' ⟶ (p ⟶ q) := by simpa only [List.disj'_singleton] using (t.consistent hΓ (show ∀ r ∈ [p ⟶ q], r ∈ t.tableau.2 by simp_all));
+      have : 𝓓 ⊬! ⋀(Γ.remove p) ⟶ (p ⟶ q) := by simpa using (t.consistent hΓ (show ∀ r ∈ [p ⟶ q], r ∈ t.tableau.2 by simp_all));
       contradiction;
     have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
     existsi t';
@@ -474,7 +474,7 @@ private lemma truthlemma.himp
     apply t'.not_mem₂_iff_mem₁.mp;
     exact not_mem₂
       (by simp_all)
-      (show 𝓓 ⊢! [p, p ⟶ q].conj' ⟶ q by
+      (show 𝓓 ⊢! ⋀[p, p ⟶ q] ⟶ q by
         simp;
         apply and_imply_iff_imply_imply'!.mpr;
         apply deduct'!;
@@ -500,8 +500,8 @@ private lemma truthlemma.hneg
         simp_all;
       replace hΔ : Δ = [] := List.nil_iff.mpr hΔ; subst hΔ;
       by_contra hC; simp at hC;
-      have : 𝓓 ⊢! (Γ.remove p).conj' ⟶ ~p := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (and₂'! neg_equiv!);
-      have : 𝓓 ⊬! (Γ.remove p).conj' ⟶ ~p := by simpa only [List.disj'_singleton] using t.consistent (Δ := [~p]) hΓ (by simpa);
+      have : 𝓓 ⊢! ⋀(Γ.remove p) ⟶ ~p := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (and₂'! neg_equiv!);
+      have : 𝓓 ⊬! ⋀(Γ.remove p) ⟶ ~p := by simpa using t.consistent (Δ := [~p]) hΓ (by simpa);
       contradiction;
     have ⟨_, _⟩ := Set.insert_subset_iff.mp h;
     existsi t';

--- a/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
+++ b/Logic/Propositional/Superintuitionistic/Kripke/Completeness.lean
@@ -32,7 +32,7 @@ lemma iff_ParametricConsistent_insert₁ : (𝓓)-Consistent ((insert p T), U) �
   . intro h Γ Δ hΓ hΔ;
     by_contra hC;
     have : 𝓓 ⊬! ⋀(p :: Γ) ⟶ ⋁Δ := h (by simp; intro q hq; right; exact hΓ q hq;) hΔ;
-    have : 𝓓 ⊢! ⋀(p :: Γ) ⟶ ⋁Δ := implyLeft_cons_conj'!.mpr hC;
+    have : 𝓓 ⊢! ⋀(p :: Γ) ⟶ ⋁Δ := iff_imply_left_cons_conj'!.mpr hC;
     contradiction;
   . intro h Γ Δ hΓ hΔ;
     simp_all only [Set.mem_insert_iff];
@@ -44,7 +44,7 @@ lemma iff_ParametricConsistent_insert₁ : (𝓓)-Consistent ((insert p T), U) �
       | inr h => assumption;
     ) hΔ;
     by_contra hC;
-    have : 𝓓 ⊢! p ⋏ ⋀(Γ.remove p) ⟶ ⋁Δ := imp_trans''! and_comm! $ imply_left_remove_conj'! (p := p) hC;
+    have : 𝓓 ⊢! p ⋏ ⋀(Γ.remove p) ⟶ ⋁Δ := imp_trans''! and_comm! $ imply_left_remove_conj! (p := p) hC;
     contradiction;
 
 lemma iff_not_ParametricConsistent_insert₁ : ¬(𝓓)-Consistent ((insert p T), U) ↔ ∃ Γ Δ : List (Formula α), (∀ p ∈ Γ, p ∈ T) ∧ (∀ p ∈ Δ, p ∈ U) ∧ 𝓓 ⊢! p ⋏ ⋀Γ ⟶ ⋁Δ := by
@@ -57,7 +57,7 @@ lemma iff_ParametricConsistent_insert₂ : (𝓓)-Consistent (T, (insert p U)) �
   . intro h Γ Δ hΓ hΔ;
     by_contra hC;
     have : 𝓓 ⊬! ⋀Γ ⟶ ⋁(p :: Δ) := h hΓ (by simp; intro q hq; right; exact hΔ q hq);
-    have : 𝓓 ⊢! ⋀Γ ⟶ ⋁(p :: Δ) := implyRight_cons_disj'!.mpr hC;
+    have : 𝓓 ⊢! ⋀Γ ⟶ ⋁(p :: Δ) := implyRight_cons_disj!.mpr hC;
     contradiction;
   . intro h Γ Δ hΓ hΔ;
     simp_all;
@@ -69,7 +69,7 @@ lemma iff_ParametricConsistent_insert₂ : (𝓓)-Consistent (T, (insert p U)) �
       | inr h => assumption;
     );
     by_contra hC;
-    have : 𝓓 ⊢! ⋀Γ ⟶ p ⋎ ⋁(Δ.remove p) := imp_trans''! hC $ forthback_disj'_remove;
+    have : 𝓓 ⊢! ⋀Γ ⟶ p ⋎ ⋁(Δ.remove p) := imp_trans''! hC $ forthback_disj_remove;
     contradiction;
 
 
@@ -449,7 +449,7 @@ private lemma truthlemma.himp
         have := by simpa using hΓ r hr₁;
         simp_all;
       by_contra hC;
-      have : 𝓓 ⊢! ⋀(Γ.remove p) ⟶ (p ⟶ q) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (by
+      have : 𝓓 ⊢! ⋀(Γ.remove p) ⟶ (p ⟶ q) := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj! hC) (by
         apply deduct'!;
         apply deduct!;
         have : [p, p ⟶ ⋁Δ] ⊢[𝓓]! p := by_axm!;
@@ -500,7 +500,7 @@ private lemma truthlemma.hneg
         simp_all;
       replace hΔ : Δ = [] := List.nil_iff.mpr hΔ; subst hΔ;
       by_contra hC; simp at hC;
-      have : 𝓓 ⊢! ⋀(Γ.remove p) ⟶ ~p := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj'! hC) (and₂'! neg_equiv!);
+      have : 𝓓 ⊢! ⋀(Γ.remove p) ⟶ ~p := imp_trans''! (and_imply_iff_imply_imply'!.mp $ imply_left_remove_conj! hC) (and₂'! neg_equiv!);
       have : 𝓓 ⊬! ⋀(Γ.remove p) ⟶ ~p := by simpa using t.consistent (Δ := [~p]) hΓ (by simpa);
       contradiction;
     have ⟨_, _⟩ := Set.insert_subset_iff.mp h;


### PR DESCRIPTION
- 証明の見通しが悪すぎるため`List.conj₂`, `List.disj₂`に対し`⋀`と`⋁`の記号を導入
- Hilbert流で`conj`, `disj`と言ったときは普通明らかに`conj₂`, `disj₂`のことを指すので`₂`は省略する．
- Modal以下の`Theory.Consistent`を`T *⊬[Λ]! ⊥`の単なる略記として書き換え．