### PR TITLE
refactor: Change parameter of Kripke canonical model

### DIFF
--- a/Logic/Modal/Standard/Kripke/Completeness.lean
+++ b/Logic/Modal/Standard/Kripke/Completeness.lean
@@ -3,24 +3,24 @@ import Logic.Modal.Standard.Kripke.Soundness
 
 namespace LO.Modal.Standard
 
-variable {α : Type*} [DecidableEq α] [Inhabited α]
-variable {Ax : AxiomSet α}
-
 open System
 open Formula
 open MaximalConsistentTheory
 open DeductionParameter (Normal)
 
+variable {α : Type*} [DecidableEq α] [Inhabited α]
+variable {Λ : DeductionParameter α} [Λ.IsNormal]
+
 namespace Kripke
 
-abbrev CanonicalFrame (Ax : AxiomSet α) [Inhabited (𝝂Ax)-MCT] : Frame where
-  World := (𝝂Ax)-MCT
+abbrev CanonicalFrame (Λ : DeductionParameter α) [Inhabited (Λ)-MCT] : Frame where
+  World := (Λ)-MCT
   Rel Ω₁ Ω₂ := □''⁻¹Ω₁.theory ⊆ Ω₂.theory
 
 namespace CanonicalFrame
 
-variable [Inhabited (𝝂Ax)-MCT]
-variable {Ω₁ Ω₂ : (CanonicalFrame Ax).World}
+variable [Inhabited (Λ)-MCT]
+variable {Ω₁ Ω₂ : (CanonicalFrame Λ).World}
 
 @[simp]
 lemma frame_def_box: Ω₁ ≺ Ω₂ ↔ ∀ {p}, □p ∈ Ω₁.theory → p ∈ Ω₂.theory := by simp [Frame.Rel']; aesop;
@@ -38,7 +38,7 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
       obtain ⟨⟨Ω₃, _⟩, R₁₃, R₃₂⟩ := h;
       apply ih.mp R₃₂ $ frame_def_box.mp R₁₃ (by simpa using hp);
     . intro h;
-      obtain ⟨Ω, hΩ⟩ := lindenbaum (Λ := 𝝂Ax) (T := (□''⁻¹Ω₁.theory ∪ ◇''^[n]Ω₂.theory)) $ by
+      obtain ⟨Ω, hΩ⟩ := lindenbaum (Λ := Λ) (T := (□''⁻¹Ω₁.theory ∪ ◇''^[n]Ω₂.theory)) $ by
         apply Theory.intro_union_consistent;
         intro Γ Δ hΓ hΔ hC;
 
@@ -52,19 +52,19 @@ lemma multiframe_def_multibox : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, □^[n]p ∈ Ω
         have hΔconj : ⋀◇'⁻¹^[n]Δ ∈ Ω₂.theory := iff_mem_conj.mpr hΔ₂;
 
         have : ⋀◇'⁻¹^[n]Δ ∉ Ω₂.theory := by {
-          have d₁ : 𝝂Ax ⊢! ⋀Γ ⟶ ⋀Δ ⟶ ⊥ := and_imply_iff_imply_imply'!.mp hC;
-          have : 𝝂Ax ⊢! ⋀(◇'^[n]◇'⁻¹^[n]Δ) ⟶ ⋀Δ := by
+          have d₁ : Λ ⊢! ⋀Γ ⟶ ⋀Δ ⟶ ⊥ := and_imply_iff_imply_imply'!.mp hC;
+          have : Λ ⊢! ⋀(◇'^[n]◇'⁻¹^[n]Δ) ⟶ ⋀Δ := by
             apply conjconj_subset!;
             intro q hq;
             obtain ⟨r, _, _⟩ := hΔ q hq;
             subst_vars;
             simpa;
-          have : 𝝂Ax ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ⟶ ⋀Δ := imp_trans''! iff_conjmultidia_multidiaconj! $ this;
-          have : 𝝂Ax ⊢! ~(□^[n](~⋀◇'⁻¹^[n]Δ)) ⟶ ⋀Δ := imp_trans''! (and₂'! multidia_duality!) this;
-          have : 𝝂Ax ⊢! ~⋀Δ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := contra₂'! this;
-          have : 𝝂Ax ⊢! (⋀Δ ⟶ ⊥) ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! (and₂'! neg_equiv!) this;
-          have : 𝝂Ax ⊢! ⋀Γ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! d₁ this;
-          have : 𝝂Ax ⊢! □⋀Γ ⟶ □^[(n + 1)](~⋀◇'⁻¹^[n]Δ) := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
+          have : Λ ⊢! ◇^[n]⋀◇'⁻¹^[n]Δ ⟶ ⋀Δ := imp_trans''! iff_conjmultidia_multidiaconj! $ this;
+          have : Λ ⊢! ~(□^[n](~⋀◇'⁻¹^[n]Δ)) ⟶ ⋀Δ := imp_trans''! (and₂'! multidia_duality!) this;
+          have : Λ ⊢! ~⋀Δ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := contra₂'! this;
+          have : Λ ⊢! (⋀Δ ⟶ ⊥) ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! (and₂'! neg_equiv!) this;
+          have : Λ ⊢! ⋀Γ ⟶ □^[n](~⋀◇'⁻¹^[n]Δ) := imp_trans''! d₁ this;
+          have : Λ ⊢! □⋀Γ ⟶ □^[(n + 1)](~⋀◇'⁻¹^[n]Δ) := by simpa only [UnaryModalOperator.multimop_succ] using imply_box_distribute'! this;
           exact iff_mem_neg.mp $ h $ membership_iff.mpr $ (Context.of! this) ⨀ dΓconj;
         }
 
@@ -90,17 +90,17 @@ lemma multiframe_def_multidia : Ω₁ ≺^[n] Ω₂ ↔ ∀ {p}, (p ∈ Ω₂.th
 end CanonicalFrame
 
 
-abbrev CanonicalModel (Ax : AxiomSet α) [Inhabited (𝝂Ax)-MCT] : Model α where
-  Frame := CanonicalFrame Ax
+abbrev CanonicalModel (Λ : DeductionParameter α) [Inhabited (Λ)-MCT]  : Model α where
+  Frame := CanonicalFrame Λ
   Valuation Ω a := (atom a) ∈ Ω.theory
 
 
 namespace CanonicalModel
 
-variable [Inhabited (𝝂Ax)-MCT]
+variable [Inhabited (Λ)-MCT]
 
 @[reducible]
-instance : Semantics (Formula α) (CanonicalModel Ax).World := Formula.Kripke.Satisfies.semantics (M := CanonicalModel Ax)
+instance : Semantics (Formula α) (CanonicalModel Λ).World := Formula.Kripke.Satisfies.semantics (M := CanonicalModel Λ)
 
 -- @[simp] lemma frame_def : (CanonicalModel Ax).Rel' Ω₁ Ω₂ ↔ (□''⁻¹Ω₁.theory : Theory α) ⊆ Ω₂.theory := by rfl
 -- @[simp] lemma val_def : (CanonicalModel Ax).Valuation Ω a ↔ (atom a) ∈ Ω.theory := by rfl
@@ -110,9 +110,9 @@ end CanonicalModel
 
 section
 
-variable [Inhabited (𝝂Ax)-MCT] {p : Formula α}
+variable [Inhabited (Λ)-MCT] {p : Formula α}
 
-lemma truthlemma : ∀ {Ω : (CanonicalModel Ax).World}, Ω ⊧ p ↔ (p ∈ Ω.theory) := by
+lemma truthlemma : ∀ {Ω : (CanonicalModel Λ).World}, Ω ⊧ p ↔ (p ∈ Ω.theory) := by
   induction p using Formula.rec' with
   | hbox p ih =>
     intro Ω;
@@ -127,15 +127,15 @@ lemma truthlemma : ∀ {Ω : (CanonicalModel Ax).World}, Ω ⊧ p ↔ (p ∈ Ω.
       exact CanonicalFrame.frame_def_box.mp hΩ' h;
   | _ => simp_all [Kripke.Satisfies];
 
-lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Ax) ⊧ p ↔ ((𝝂Ax) ⊢! p) := by
+lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Λ) ⊧ p ↔ Λ ⊢! p := by
   constructor;
   . contrapose;
     intro h;
-    have : (𝝂Ax)-Consistent ({~p}) := by
+    have : (Λ)-Consistent ({~p}) := by
       apply Theory.def_consistent.mpr;
       intro Γ hΓ;
       by_contra hC;
-      have : 𝝂Ax ⊢! p := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
+      have : Λ ⊢! p := dne'! $ neg_equiv'!.mpr $ replace_imply_left_conj! hΓ hC;
       contradiction;
     obtain ⟨Ω, hΩ⟩ := lindenbaum this;
     simp [Kripke.ValidOnModel];
@@ -145,17 +145,17 @@ lemma iff_valid_on_canonicalModel_deducible : (CanonicalModel Ax) ⊧ p ↔ ((�
     suffices p ∈ Ω.theory by exact truthlemma.mpr this;
     by_contra hC;
     obtain ⟨Γ, hΓ₁, hΓ₂⟩ := Theory.iff_insert_inconsistent.mp $ Ω.maximal' hC;
-    have : Γ ⊢[𝝂Ax]! ⊥ := FiniteContext.provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hΓ₂ ⨀ h;
-    have : Γ ⊬[𝝂Ax]! ⊥ := Theory.def_consistent.mp Ω.consistent _ hΓ₁;
+    have : Γ ⊢[Λ]! ⊥ := FiniteContext.provable_iff.mpr $ and_imply_iff_imply_imply'!.mp hΓ₂ ⨀ h;
+    have : Γ ⊬[Λ]! ⊥ := Theory.def_consistent.mp Ω.consistent _ hΓ₁;
     contradiction;
 
-lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Ax) ⊧* Ax := by
+lemma realize_axiomset_of_self_canonicalModel : (CanonicalModel Λ) ⊧* Ax(Λ) := by
   apply Semantics.realizeSet_iff.mpr;
   intro p hp;
   apply iff_valid_on_canonicalModel_deducible.mpr;
-  exact Deduction.maxm! (by aesop);
+  exact Deduction.maxm! (by assumption);
 
-lemma realize_theory_of_self_canonicalModel : (CanonicalModel Ax) ⊧* (System.theory (𝝂Ax)) := by
+lemma realize_theory_of_self_canonicalModel : (CanonicalModel Λ) ⊧* (System.theory Λ) := by
   apply Semantics.realizeSet_iff.mpr;
   intro p hp;
   apply iff_valid_on_canonicalModel_deducible.mpr;
@@ -163,21 +163,21 @@ lemma realize_theory_of_self_canonicalModel : (CanonicalModel Ax) ⊧* (System.t
 
 end
 
-lemma complete_of_mem_canonicalFrame [Inhabited (𝝂Ax)-MCT] {𝔽 : FrameClass.Dep α} (hFC : CanonicalFrame Ax ∈ 𝔽) : 𝔽 ⊧ p → (𝝂Ax) ⊢! p := by
+lemma complete_of_mem_canonicalFrame [Inhabited (Λ)-MCT] {𝔽 : FrameClass.Dep α} (hFC : CanonicalFrame Λ ∈ 𝔽) : 𝔽 ⊧ p → (Λ) ⊢! p := by
   simp [Kripke.ValidOnFrameClass, Kripke.ValidOnFrame];
   contrapose;
   push_neg;
   intro h;
-  use (CanonicalFrame Ax);
+  use (CanonicalFrame Λ);
   constructor;
   . assumption;
-  . use (CanonicalModel Ax).Valuation;
+  . use (CanonicalModel Λ).Valuation;
     exact iff_valid_on_canonicalModel_deducible.not.mpr h;
 
-lemma instComplete_of_mem_canonicalFrame [Inhabited (𝝂Ax)-MCT] {𝔽 : FrameClass.Dep α} (hFC : CanonicalFrame Ax ∈ 𝔽) : Complete (𝝂Ax) 𝔽 := ⟨complete_of_mem_canonicalFrame hFC⟩
+lemma instComplete_of_mem_canonicalFrame [Inhabited (Λ)-MCT] {𝔽 : FrameClass.Dep α} (hFC : CanonicalFrame Λ ∈ 𝔽) : Complete (Λ) 𝔽 := ⟨complete_of_mem_canonicalFrame hFC⟩
 
 instance K_complete : Complete (𝐊 : DeductionParameter α) AllFrameClass# := by
-  simpa [←Normal.isK] using instComplete_of_mem_canonicalFrame (Ax := 𝗞) (𝔽 := AllFrameClass#) trivial;
+  simpa [←Normal.isK] using instComplete_of_mem_canonicalFrame (Λ := 𝐊) (𝔽 := AllFrameClass#) trivial;
 
 end Kripke
 

--- a/Logic/Modal/Standard/Kripke/Dot3.lean
+++ b/Logic/Modal/Standard/Kripke/Dot3.lean
@@ -74,7 +74,7 @@ instance : System.Consistent (𝐒𝟒.𝟑 : DeductionParameter α) := consiste
 
 
 open MaximalConsistentTheory in
-lemma connected_CanonicalFrame {Ax : AxiomSet α} (hAx : .𝟯 ⊆ Ax) [System.Consistent (𝝂Ax)] : Connected (CanonicalFrame Ax) := by
+lemma connected_CanonicalFrame {Ax : AxiomSet α} (hAx : .𝟯 ⊆ Ax) [System.Consistent (𝝂Ax)] : Connected (CanonicalFrame 𝝂Ax) := by
   dsimp only [Connected];
   intro X Y Z ⟨hXY, hXZ⟩;
   by_contra hC; push_neg at hC;
@@ -108,7 +108,8 @@ instance : Complete (𝐒𝟒.𝟑 : DeductionParameter α) (ReflexiveTransitive
   . rw [←GeachConfluent.transitive_def];
     apply geachConfluent_CanonicalFrame;
     simp [AxiomSet.Geach.Four_def];
-  . apply connected_CanonicalFrame; simp;
+  . apply connected_CanonicalFrame;
+    simp;
 
 end Kripke
 

--- a/Logic/Modal/Standard/Kripke/Geach.lean
+++ b/Logic/Modal/Standard/Kripke/Geach.lean
@@ -238,7 +238,7 @@ open DeductionParameter (Normal)
 
 variable {Ax : AxiomSet α} [System.Consistent (𝝂Ax)]
 
-lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t (CanonicalFrame Ax):= by
+lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t (CanonicalFrame 𝝂Ax):= by
   rintro Ω₁ Ω₂ Ω₃ h;
   have ⟨r₁₂, r₁₃⟩ := h; clear h;
   have ⟨Ω, hΩ⟩ := lindenbaum (Λ := 𝝂Ax) (T := □''⁻¹^[t.m]Ω₂.theory ∪ □''⁻¹^[t.n]Ω₃.theory) $ by
@@ -271,7 +271,7 @@ lemma geachConfluent_CanonicalFrame (h : 𝗴𝗲(t) ⊆ Ax) : GeachConfluent t 
   . apply multiframe_def_multibox.mpr; apply hΩ.1;
   . apply multiframe_def_multibox.mpr; apply hΩ.2;
 
-lemma multiGeachConfluent_CanonicalFrame (h : 𝗚𝗲(ts) ⊆ Ax) : MultiGeachConfluent ts (CanonicalFrame Ax) := by
+lemma multiGeachConfluent_CanonicalFrame (h : 𝗚𝗲(ts) ⊆ Ax) : MultiGeachConfluent ts (CanonicalFrame 𝝂Ax) := by
   induction ts with
   | nil => simp [MultiGeachConfluent];
   | cons t ts ih =>
@@ -295,13 +295,13 @@ private def instGeachLogicCompleteAux {Λ : DeductionParameter α} [geach : Λ.I
     convert instMultiGeachComplete (α := α);
     exact geach.char;
 
-instance : Complete (𝐊𝐓 : DeductionParameter α) (ReflexiveFrameClass#) := instGeachLogicCompleteAux
+instance : Complete (𝐊𝐓 : DeductionParameter α) ReflexiveFrameClass# := instGeachLogicCompleteAux
 
-instance : Complete (𝐒𝟒 : DeductionParameter α) (PreorderFrameClass#) := instGeachLogicCompleteAux
+instance : Complete (𝐒𝟒 : DeductionParameter α) PreorderFrameClass# := instGeachLogicCompleteAux
 
-instance : Complete (𝐒𝟓 : DeductionParameter α) (ReflexiveEuclideanFrameClass#) := instGeachLogicCompleteAux
+instance : Complete (𝐒𝟓 : DeductionParameter α) ReflexiveEuclideanFrameClass# := instGeachLogicCompleteAux
 
-instance : Complete (𝐊𝐓𝟒𝐁 : DeductionParameter α) (EquivalenceFrameClass#) := instGeachLogicCompleteAux
+instance : Complete (𝐊𝐓𝟒𝐁 : DeductionParameter α) EquivalenceFrameClass# := instGeachLogicCompleteAux
 
 end Completeness
 

--- a/Logic/Modal/Standard/Kripke/Ver.lean
+++ b/Logic/Modal/Standard/Kripke/Ver.lean
@@ -32,9 +32,9 @@ instance : Sound (𝐕𝐞𝐫 : DeductionParameter α) IsolatedFrameClass# := s
 
 instance : System.Consistent (𝐕𝐞𝐫 : DeductionParameter α) := consistent_of_defines axiomVer_defines IsolatedFrameClass.nonempty
 
-lemma isolated_CanonicalFrame {Ax : AxiomSet α} (h : 𝗩𝗲𝗿 ⊆ Ax) [System.Consistent (𝝂Ax)] : Isolated (CanonicalFrame Ax) := by
+lemma isolated_CanonicalFrame {Ax : AxiomSet α} (h : 𝗩𝗲𝗿 ⊆ Ax) [System.Consistent 𝝂Ax] : Isolated (CanonicalFrame 𝝂Ax) := by
   intro x y rxy;
-  have : (CanonicalModel Ax) ⊧ □⊥ := iff_valid_on_canonicalModel_deducible.mpr $ Normal.maxm! (by aesop);
+  have : (CanonicalModel 𝝂Ax) ⊧ □⊥ := iff_valid_on_canonicalModel_deducible.mpr $ Normal.maxm! (by aesop);
   exact this x rxy;
 
 instance : Complete (𝐕𝐞𝐫 : DeductionParameter α) IsolatedFrameClass# := instComplete_of_mem_canonicalFrame $ isolated_CanonicalFrame (by rfl)


### PR DESCRIPTION
Kripke意味論のカノニカルモデルのパラメータを公理集合にしていたが面倒なので普通に`Λ`で与えるようにした．`𝐆𝐋`の完全性をこれでやってみて支障が無さそうならマージする．